### PR TITLE
HARNESS-CHG-20260428-02 추적 ID 추상화 follow-up — 잔존 흠 + 부수발견 수리 + smoke regression

### DIFF
--- a/harness/core.py
+++ b/harness/core.py
@@ -18,8 +18,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from .config import HarnessConfig, load_config
+    from .tracker import format_ref, parse_ref, get_tracker_for
 except ImportError:
     from config import HarnessConfig, load_config
+    from tracker import format_ref, parse_ref, get_tracker_for
 
 # Plugin root resolution — CLAUDE_PLUGIN_ROOT env에 폴백 ~/.claude.
 # 플러그인 마켓플레이스 설치 시 CLAUDE_PLUGIN_ROOT 가 자동 set됨.
@@ -290,7 +292,7 @@ class HUD:
             except OSError:
                 pass
         mode = "plan" if depth == "plan" else "impl"
-        issue_str = f" #{issue_num}" if issue_num else ""
+        issue_str = f" {format_ref(issue_num)}" if issue_num else ""
         self._event(f"{'═' * 50}")
         self._event(f"루프 시작 | mode={mode} depth={depth}{issue_str}")
 
@@ -1377,33 +1379,32 @@ def create_feature_branch(
     """Feature branch 생성. 동일 브랜치 존재 시 재진입."""
     issue_num = str(issue_num)
 
-    # milestone: GitHub 이슈에서 읽기
-    milestone = ""
+    # milestone + title: tracker 백엔드 경유 (GitHub gh / Local jsonl 모두 동작).
+    # 기존 직접 gh issue view 호출 2회 → tracker.get_issue() 1회로 통합.
+    # silent fail 정책 보존 — 백엔드 미가용 시 milestone/slug 빈 채로 진행.
+    issue_meta: Dict[str, Any] = {}
     try:
-        r = subprocess.run(
-            ["gh", "issue", "view", issue_num, "--json", "milestone", "-q", ".milestone.title"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            milestone = re.sub(r"[^a-z0-9-]", "-", r.stdout.strip().lower())
-            milestone = re.sub(r"-+", "-", milestone).strip("-")
+        ref = parse_ref(issue_num)
+        issue_meta = get_tracker_for(ref).get_issue(ref)
     except Exception:
         pass
 
-    # slug: issue title → 영문/숫자, 30자 캡
+    # milestone 추출 — github 백엔드는 dict({"title": ...}), local 은 string
+    ms_field = issue_meta.get("milestone")
+    ms_str = ms_field.get("title", "") if isinstance(ms_field, dict) else (ms_field or "")
+    milestone = ""
+    if ms_str:
+        milestone = re.sub(r"[^a-z0-9-]", "-", ms_str.lower())
+        milestone = re.sub(r"-+", "-", milestone).strip("-")
+
+    # slug — title 30자 캡
     slug = ""
-    try:
-        r = subprocess.run(
-            ["gh", "issue", "view", issue_num, "--json", "title", "-q", ".title"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            raw = r.stdout.strip().lower()
-            raw = re.sub(r"[^a-z0-9 -]", "", raw)
-            raw = re.sub(r"\s+", " ", raw).strip()
-            slug = re.sub(r"-+", "-", raw.replace(" ", "-")).strip("-")[:30]
-    except Exception:
-        pass
+    title = issue_meta.get("title") or ""
+    if title:
+        raw = title.lower()
+        raw = re.sub(r"[^a-z0-9 -]", "", raw)
+        raw = re.sub(r"\s+", " ", raw).strip()
+        slug = re.sub(r"-+", "-", raw.replace(" ", "-")).strip("-")[:30]
 
     # 브랜치명 조립
     branch_name = f"{branch_type}/"
@@ -1468,10 +1469,10 @@ def push_and_ensure_pr(
 
     # PR 생성
     impl_name = Path(impl_file).stem if impl_file else f"issue-{issue}"
-    pr_title = f"feat: {impl_name} (#{issue})"
+    pr_title = f"feat: {impl_name} ({format_ref(issue)})"
 
     # PR body: generate_pr_body 시도 (순환 의존 방지 lazy import), 실패 시 간단 body
-    pr_body = f"## Summary\n- Issue: #{issue}\n- Branch: `{branch}`\n- Depth: {depth}"
+    pr_body = f"## Summary\n- Issue: {format_ref(issue)}\n- Branch: `{branch}`\n- Depth: {depth}"
     if impl_file and state_dir and prefix:
         try:
             try:
@@ -1587,13 +1588,13 @@ def generate_commit_msg(impl_file: str = "", issue_num: str | int = "") -> str:
     changed = " ".join(r.stdout.strip().splitlines()[:5]) if r.returncode == 0 else "(파일 목록 없음)"
 
     return (
-        f"feat: implement {impl_name} (#{issue_num})\n"
+        f"feat: implement {impl_name} ({format_ref(issue_num)})\n"
         f"\n"
-        f"[왜] Issue #{issue_num} 구현\n"
+        f"[왜] Issue {format_ref(issue_num)} 구현\n"
         f"[변경]\n"
         f"- {changed}\n"
         f"\n"
-        f"Closes #{issue_num}\n"
+        f"Closes {format_ref(issue_num)}\n"
         f"\n"
         f"Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
     )
@@ -1898,7 +1899,7 @@ def generate_handoff(
     if impl_file:
         sections.append(f"impl: {impl_file}")
     if issue_num:
-        sections.append(f"issue: #{issue_num}")
+        sections.append(f"issue: {format_ref(issue_num)}")
     sections.append("")
 
     # 변경 요약
@@ -2167,7 +2168,7 @@ def run_plan_validation(
     print("[HARNESS] Plan Validation")
     agent_call(
         "validator", 300,
-        f"@MODE:VALIDATOR:PLAN_VALIDATION\nimpl: {impl_file} issue: #{issue_num}{handoff_hint}",
+        f"@MODE:VALIDATOR:PLAN_VALIDATION\nimpl: {impl_file} issue: {format_ref(issue_num)}{handoff_hint}",
         val_out, run_logger, config,
     )
     val_result = parse_marker(val_out, "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
@@ -2218,7 +2219,7 @@ def run_plan_validation(
         val_out2 = str(state_dir.path / f"{prefix}_val_pv_out{rework}.txt")
         agent_call(
             "validator", 300,
-            f"@MODE:VALIDATOR:PLAN_VALIDATION\nimpl: {impl_file} issue: #{issue_num}",
+            f"@MODE:VALIDATOR:PLAN_VALIDATION\nimpl: {impl_file} issue: {format_ref(issue_num)}",
             val_out2, run_logger, config,
         )
         val_result = parse_marker(val_out2, "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
@@ -2253,7 +2254,7 @@ def run_design_validation(
     print("[HARNESS] Design Validation")
     agent_call(
         "validator", 300,
-        f"@MODE:VALIDATOR:DESIGN_VALIDATION\ndesign_doc: {design_doc} issue: #{issue_num}",
+        f"@MODE:VALIDATOR:DESIGN_VALIDATION\ndesign_doc: {design_doc} issue: {format_ref(issue_num)}",
         val_out, run_logger, config,
     )
     val_result = parse_marker(val_out, "DESIGN_REVIEW_PASS|DESIGN_REVIEW_FAIL|PASS|FAIL")
@@ -2287,7 +2288,7 @@ def run_design_validation(
         val_out2 = str(state_dir.path / f"{prefix}_val_dv_out{rework}.txt")
         agent_call(
             "validator", 300,
-            f"@MODE:VALIDATOR:DESIGN_VALIDATION\ndesign_doc: {design_doc} issue: #{issue_num}",
+            f"@MODE:VALIDATOR:DESIGN_VALIDATION\ndesign_doc: {design_doc} issue: {format_ref(issue_num)}",
             val_out2, run_logger, config,
         )
         val_result = parse_marker(val_out2, "DESIGN_REVIEW_PASS|DESIGN_REVIEW_FAIL|PASS|FAIL")
@@ -2322,7 +2323,7 @@ def run_ux_validation(
     print("[HARNESS] UX Validation")
     agent_call(
         "validator", 300,
-        f"@MODE:VALIDATOR:UX_VALIDATION\nux_flow_doc: {ux_flow_doc}\nprd_path: {prd_path}\nissue: #{issue_num}",
+        f"@MODE:VALIDATOR:UX_VALIDATION\nux_flow_doc: {ux_flow_doc}\nprd_path: {prd_path}\nissue: {format_ref(issue_num)}",
         val_out, run_logger, config,
     )
     val_result = parse_marker(val_out, "UX_REVIEW_PASS|UX_REVIEW_FAIL|PASS|FAIL")
@@ -2357,7 +2358,7 @@ def run_ux_validation(
         val_out2 = str(state_dir.path / f"{prefix}_val_ux_out{rework}.txt")
         agent_call(
             "validator", 300,
-            f"@MODE:VALIDATOR:UX_VALIDATION\nux_flow_doc: {ux_flow_doc}\nprd_path: {prd_path}\nissue: #{issue_num}",
+            f"@MODE:VALIDATOR:UX_VALIDATION\nux_flow_doc: {ux_flow_doc}\nprd_path: {prd_path}\nissue: {format_ref(issue_num)}",
             val_out2, run_logger, config,
         )
         val_result = parse_marker(val_out2, "UX_REVIEW_PASS|UX_REVIEW_FAIL|PASS|FAIL")

--- a/harness/executor.py
+++ b/harness/executor.py
@@ -38,9 +38,11 @@ def main() -> None:
     try:
         from .config import load_config
         from .core import StateDir, RunLogger, Flag, find_main_repo_root
+        from .tracker import format_ref, normalize_issue_num
     except ImportError:
         from config import load_config
         from core import StateDir, RunLogger, Flag, find_main_repo_root
+        from tracker import format_ref, normalize_issue_num
 
     # L2 방어: cwd가 worktree 내부로 persist된 상태면 main repo root로 복귀.
     # Claude Code Bash tool은 세션 간 cwd를 유지하므로 `cd .worktrees/...` 이후 호출 시
@@ -55,7 +57,9 @@ def main() -> None:
 
     config = load_config()
     prefix = args.prefix or config.prefix
-    issue_num = getattr(args, "issue_num", "") or ""
+    # 진입점에서 normalize — 디렉토리·flag·env 안전한 internal 형식으로 변환.
+    # "#42" → "42", "LOCAL-7" 보존, 빈 문자열은 그대로.
+    issue_num = normalize_issue_num(getattr(args, "issue_num", "") or "")
 
     # Phase 3: 세션 ID 부팅 — HARNESS_SESSION_ID env → .session-id 파일
     sys.path.insert(0, str(PLUGIN_ROOT / "hooks"))
@@ -85,7 +89,7 @@ def main() -> None:
         if cooldown:
             from datetime import datetime
             ts = datetime.fromtimestamp(cooldown.get("timestamp", 0)).strftime("%Y-%m-%d %H:%M:%S")
-            print(f"[HARNESS] ⚠️ 이슈 #{issue_num} cooldown 중 — {cooldown.get('reason')} ({ts})")
+            print(f"[HARNESS] ⚠️ 이슈 {format_ref(issue_num)} cooldown 중 — {cooldown.get('reason')} ({ts})")
             print(f"  branch: {cooldown.get('branch','?')}")
             if cooldown.get("stderr_tail"):
                 print(f"  사유: {cooldown['stderr_tail'][:200]}")
@@ -101,14 +105,14 @@ def main() -> None:
         except ImportError:
             from core import clear_merge_cooldown
         clear_merge_cooldown(Path.cwd(), prefix, issue_num)
-        print(f"[HARNESS] cooldown 우회: 이슈 #{issue_num}")
+        print(f"[HARNESS] cooldown 우회: 이슈 {format_ref(issue_num)}")
 
     # Phase 3: 이슈 lock 획득 — 두 세션이 같은 이슈 동시 작업 방지
     if ss is not None and session_id and issue_num:
         try:
             ok, holder = ss.claim_issue_lock(prefix, issue_num, session_id, mode=args.mode)
             if not ok and holder:
-                print(f"[HARNESS] 오류: 이슈 #{issue_num}은 세션 {holder.get('session_id','')[:8]}…가 "
+                print(f"[HARNESS] 오류: 이슈 {format_ref(issue_num)}은 세션 {holder.get('session_id','')[:8]}…가 "
                       f"PID {holder.get('pid')}로 이미 작업 중입니다.")
                 print("동시 작업은 지원하지 않습니다. /harness-kill 또는 세션 완료를 기다리세요.")
                 sys.exit(1)

--- a/harness/helpers.py
+++ b/harness/helpers.py
@@ -18,10 +18,12 @@ try:
     from .core import (
         Flag, RunLogger, StateDir, hlog, write_attempt_meta,
     )
+    from .tracker import format_ref
 except ImportError:
     from core import (
         Flag, RunLogger, StateDir, hlog, write_attempt_meta,
     )
+    from tracker import format_ref
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -560,7 +562,7 @@ def generate_pr_body(
             pr_notes = " ".join(notes)
 
     # 결정 근거
-    why = f"Issue #{issue_num} 구현"
+    why = f"Issue {format_ref(issue_num)} 구현"
     try:
         impl_text = Path(impl_file).read_text(encoding="utf-8")
         in_section = False
@@ -576,7 +578,7 @@ def generate_pr_body(
 
     return (
         f"## What / Why\n"
-        f"Issue #{issue_num} — `{impl_name}`\n"
+        f"Issue {format_ref(issue_num)} — `{impl_name}`\n"
         f"{why}\n\n"
         f"## 작동 증거\n"
         f"- test: {test_summary}\n"

--- a/harness/impl_loop.py
+++ b/harness/impl_loop.py
@@ -35,6 +35,7 @@ try:
         extract_acceptance_criteria, extract_polish_items,
     )
     from .providers import run_review_batch
+    from .tracker import format_ref
 except ImportError:
     from config import HarnessConfig, load_config
     from core import (
@@ -55,6 +56,7 @@ except ImportError:
         extract_acceptance_criteria, extract_polish_items,
     )
     from providers import run_review_batch
+    from tracker import format_ref
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -371,7 +373,7 @@ def run_simple(
         _eng_t0 = time.time()
         agent_exit = agent_call(
             "engineer", 900,
-            f"impl: {impl_file}\nissue: #{issue_num}\ntask:\n{task}\n"
+            f"impl: {impl_file}\nissue: {format_ref(issue_num)}\ntask:\n{task}\n"
             f"context:\n{context}\nconstraints:\n{constraints}{_val_handoff_hint}",
             eng_out, run_logger, config, str(attempt_dir),
         )
@@ -437,7 +439,7 @@ def run_simple(
             agent_call(
                 "architect", 900,
                 f"@MODE:ARCHITECT:SPEC_GAP\n"
-                f"engineer가 SPEC_GAP_FOUND 보고. impl: {impl_file} issue: #{issue_num}\n"
+                f"engineer가 SPEC_GAP_FOUND 보고. impl: {impl_file} issue: {format_ref(issue_num)}\n"
                 f"인수인계 문서: {_sg_handoff_path}\n"
                 f"현재 depth: simple\nengineer 보고:\n{spec_gap_context}\n"
                 f"[지시] SPEC_GAP 해결 후 depth 재판정. frontmatter depth: 필드를 재선언하라. "
@@ -706,7 +708,7 @@ def run_simple(
                     )
                     subprocess.run(["git", "add", "--"] + _polish_changed, capture_output=True, timeout=10)
                     subprocess.run(
-                        ["git", "commit", "-m", f"revert: polish regression (#{issue_num})"],
+                        ["git", "commit", "-m", f"revert: polish regression ({format_ref(issue_num)})"],
                         capture_output=True, timeout=10,
                     )
                     hlog_fn(f"POLISH revert 커밋 ({len(_polish_changed)} files)")
@@ -717,7 +719,7 @@ def run_simple(
                 if _changed:
                     subprocess.run(["git", "add", "--"] + _changed, capture_output=True, timeout=10)
                     subprocess.run(
-                        ["git", "commit", "-m", f"polish: code cleanup (#{issue_num})"],
+                        ["git", "commit", "-m", f"polish: code cleanup ({format_ref(issue_num)})"],
                         capture_output=True, timeout=10,
                     )
                     hlog_fn("POLISH 커밋 완료")
@@ -785,7 +787,7 @@ def run_simple(
         hlog_fn(f"=== 루프 종료 (HARNESS_DONE, attempt={attempt + 1}) ===")
         print("HARNESS_DONE")
         print(f"impl: {impl_file}")
-        print(f"issue: #{issue_num}")
+        print(f"issue: {format_ref(issue_num)}")
         print(f"attempts: {attempt + 1}")
         print(f"commit: {merge_commit}")
         print(f"pr_body: {pr_body_file}")
@@ -935,7 +937,7 @@ def _run_std_deep(
                 f"@MODE:TEST_ENGINEER:TDD\n"
                 f'@PARAMS: {{ "impl_path": "{impl_file}" }}\n\n'
                 f"[지시] impl의 인터페이스 정의 + 수용 기준(TEST)에서 테스트 작성. 코드 없이 impl만 참조.\n"
-                f"issue: #{issue_num}"
+                f"issue: {format_ref(issue_num)}"
             )
             _te_tdd_t0 = time.time()
             te_tdd_exit = agent_call("test-engineer", 900, te_tdd_prompt, te_tdd_out, run_logger, config, str(attempt_dir))
@@ -1060,7 +1062,7 @@ def _run_std_deep(
         _eng_t0 = time.time()
         agent_exit = agent_call(
             "engineer", 900,
-            f"impl: {impl_file}\nissue: #{issue_num}\ntask:\n{task}\n"
+            f"impl: {impl_file}\nissue: {format_ref(issue_num)}\ntask:\n{task}\n"
             f"context:\n{context}\nconstraints:\n{constraints}",
             eng_out, run_logger, config, str(attempt_dir),
         )
@@ -1118,7 +1120,7 @@ def _run_std_deep(
             if depth == "deep":
                 sg_prompt = (
                     f"@MODE:ARCHITECT:SPEC_GAP\n"
-                    f"engineer가 SPEC_GAP_FOUND 보고. impl: {impl_file} issue: #{issue_num}\n"
+                    f"engineer가 SPEC_GAP_FOUND 보고. impl: {impl_file} issue: {format_ref(issue_num)}\n"
                     f"인수인계 문서: {_sg_handoff_path2}\n"
                     f"현재 depth: deep (최고 depth — 하향 없음)\n"
                     f"engineer 보고:\n{spec_gap_ctx}\n"
@@ -1127,7 +1129,7 @@ def _run_std_deep(
             else:
                 sg_prompt = (
                     f"@MODE:ARCHITECT:SPEC_GAP\n"
-                    f"engineer가 SPEC_GAP_FOUND 보고. impl: {impl_file} issue: #{issue_num}\n"
+                    f"engineer가 SPEC_GAP_FOUND 보고. impl: {impl_file} issue: {format_ref(issue_num)}\n"
                     f"현재 depth: {depth}\nengineer 보고:\n{spec_gap_ctx}\n"
                     f"[지시] SPEC_GAP 해결 후 depth 재판정. frontmatter depth: 필드를 재선언하라. "
                     f"상향만 허용(simple→std→deep)."
@@ -1244,7 +1246,7 @@ def _run_std_deep(
                 f'@PARAMS: {{ "impl_path": "{impl_file}" }}\n\n'
                 f"[지시] impl + 구현 코드 기반으로 테스트 작성. 테스트 실행은 하지 마라 (test_command 미설정).\n"
                 f"수정된 파일: {changed_files_str}\n"
-                f"issue: #{issue_num}"
+                f"issue: {format_ref(issue_num)}"
                 f"{_te_handoff_hint}"
             )
 
@@ -1357,7 +1359,7 @@ def _run_std_deep(
             arch_sm_out = str(state_dir.path / f"{prefix}_arch_sm_out.txt")
             agent_call(
                 "architect", 900,
-                f"@MODE:ARCHITECT:MODULE_PLAN\nSPEC_MISSING 복구. impl: {impl_file} issue: #{issue_num}",
+                f"@MODE:ARCHITECT:MODULE_PLAN\nSPEC_MISSING 복구. impl: {impl_file} issue: {format_ref(issue_num)}",
                 arch_sm_out, run_logger, config,
             )
             budget_check("architect", arch_sm_out, total_cost, config.max_total_cost, state_dir, prefix, config=config)
@@ -1525,7 +1527,7 @@ def _run_std_deep(
                     )
                     subprocess.run(["git", "add", "--"] + _polish_changed, capture_output=True, timeout=10)
                     subprocess.run(
-                        ["git", "commit", "-m", f"revert: polish regression (#{issue_num})"],
+                        ["git", "commit", "-m", f"revert: polish regression ({format_ref(issue_num)})"],
                         capture_output=True, timeout=10,
                     )
                     hlog_fn(f"POLISH revert 커밋 ({len(_polish_changed)} files)")
@@ -1535,7 +1537,7 @@ def _run_std_deep(
                 if _changed:
                     subprocess.run(["git", "add", "--"] + _changed, capture_output=True, timeout=10)
                     subprocess.run(
-                        ["git", "commit", "-m", f"polish: code cleanup (#{issue_num})"],
+                        ["git", "commit", "-m", f"polish: code cleanup ({format_ref(issue_num)})"],
                         capture_output=True, timeout=10,
                     )
                     hlog_fn("POLISH 커밋 완료")
@@ -1661,7 +1663,7 @@ def _run_std_deep(
         hlog_fn(f"=== 루프 종료 (HARNESS_DONE, attempt={attempt + 1}) ===")
         print("HARNESS_DONE")
         print(f"impl: {impl_file}")
-        print(f"issue: #{issue_num}")
+        print(f"issue: {format_ref(issue_num)}")
         print(f"attempts: {attempt + 1}")
         print(f"commit: {merge_commit}")
         print(f"pr_body: {pr_body_file}")

--- a/harness/impl_router.py
+++ b/harness/impl_router.py
@@ -25,6 +25,7 @@ try:
         record_escalate,
     )
     from .impl_loop import run_simple, run_std, run_deep
+    from .tracker import format_ref
 except ImportError:
     from config import HarnessConfig
     from core import (
@@ -37,6 +38,7 @@ except ImportError:
         record_escalate,
     )
     from impl_loop import run_simple, run_std, run_deep
+    from tracker import format_ref
 
 
 def _maybe_auto_spec_gap(
@@ -73,7 +75,7 @@ def _maybe_auto_spec_gap(
         f"@MODE:ARCHITECT:SPEC_GAP\n"
         f"이 impl 파일이 직전 run들에서 {count}회 IMPLEMENTATION_ESCALATE됐다.\n"
         f"impl: {impl_file}\n"
-        f"issue: #{issue_num}\n"
+        f"issue: {format_ref(issue_num)}\n"
         f"누적 fail_types: {fail_types}\n\n"
         f"같은 fail_type이 반복되는 원인은 impl 스펙 자체에 갭이 있다는 신호다. "
         f"impl 파일을 읽고 다음 중 하나로 대응하라:\n"
@@ -158,7 +160,7 @@ def ensure_depth_frontmatter(
         f"주의: 기존 테스트가 assertion하는 DOM 구조/텍스트 리터럴/testid/role을 바꾸는 경우 "
         f"(이모지→SVG, 버튼 텍스트 변경, 엘리먼트 교체 등) simple 금지 — std로 분류. "
         f"TDD 선행이 있어야 회귀를 잡는다.\n"
-        f"impl: {impl_file}\nissue: #{issue_num}\n"
+        f"impl: {impl_file}\nissue: {format_ref(issue_num)}\n"
         f"기존 frontmatter 유무: {fm_status}\n"
         f"파일 내용 확인 후 depth만 추가하라. 다른 내용은 수정하지 마라.",
         patch_out, run_logger, config,
@@ -352,12 +354,12 @@ def run_impl(
             elif state_dir.flag_exists(Flag.DESIGN_CRITIC_PASSED):
                 print("[HARNESS] ⚠️ design_critic_passed 플래그 있으나 design_handoff.md 없음 — architect가 디자인 스펙 없이 진행")
 
-            print(f"[HARNESS] architect LIGHT_PLAN 작성 (issue #{issue_num}, depth_hint={depth_hint or 'none'})")
-            hud.log(f"architect LIGHT_PLAN (issue #{issue_num})")
+            print(f"[HARNESS] architect LIGHT_PLAN 작성 (issue {format_ref(issue_num)}, depth_hint={depth_hint or 'none'})")
+            hud.log(f"architect LIGHT_PLAN (issue {format_ref(issue_num)})")
             arch_exit = agent_call(
                 "architect", 900,
                 f"@MODE:ARCHITECT:LIGHT_PLAN\n"
-                f"issue #{issue_num}\n"
+                f"issue {format_ref(issue_num)}\n"
                 f"suspected_files: {suspected_files}\n"
                 f"labels: {issue_labels}\n"
                 f"issue_summary:\n{issue_summary}\n"
@@ -376,7 +378,7 @@ def run_impl(
             )
         else:
             print("[HARNESS] architect Module Plan 작성")
-            hud.log(f"architect Module Plan (issue #{issue_num})")
+            hud.log(f"architect Module Plan (issue {format_ref(issue_num)})")
             _mp_extra = ""
             if Path("docs/design-handoff.md").exists():
                 _mp_extra = "\ndesign_handoff: docs/design-handoff.md"
@@ -386,7 +388,7 @@ def run_impl(
             arch_exit = agent_call(
                 "architect", 900,
                 f"@MODE:ARCHITECT:MODULE_PLAN\n"
-                f"issue #{issue_num} impl 계획 작성. context: {context}{_mp_extra}",
+                f"issue {format_ref(issue_num)} impl 계획 작성. context: {context}{_mp_extra}",
                 arch_out, run_logger, config,
             )
 
@@ -492,7 +494,7 @@ def run_impl(
         (state_dir.path / f"{prefix}_impl_path").write_text(impl_file, encoding="utf-8")
         print("PLAN_VALIDATION_PASS")
         print(f"impl: {impl_file}")
-        print(f"issue: #{issue_num}")
+        print(f"issue: {format_ref(issue_num)}")
 
         if depth == "auto":
             depth = detect_depth(impl_file)

--- a/harness/notify.py
+++ b/harness/notify.py
@@ -63,7 +63,15 @@ def notify(
     m, s = divmod(max(0, int(elapsed)), 60)
     head = f"[{tag}] prefix={prefix or '?'}"
     if issue:
-        head += f" issue=#{issue}"
+        # tracker.format_ref 사용 — "#42" / "LOCAL-7" 일관 표기. lazy import 로 순환 회피.
+        try:
+            try:
+                from .tracker import format_ref as _fr
+            except ImportError:
+                from tracker import format_ref as _fr  # type: ignore
+            head += f" issue={_fr(issue)}"
+        except Exception:
+            head += f" issue=#{issue}"  # 폴백: tracker 미가용 시 legacy 표기
     head += f" ({m}m{s:02d}s"
     if cost_usd > 0:
         head += f", ${cost_usd:.2f}"

--- a/harness/plan_loop.py
+++ b/harness/plan_loop.py
@@ -21,6 +21,7 @@ try:
         build_loop_context, run_ux_validation,
         generate_handoff, write_handoff,
     )
+    from .tracker import format_ref
 except ImportError:
     from config import HarnessConfig
     from core import (
@@ -29,6 +30,7 @@ except ImportError:
         build_loop_context, run_ux_validation,
         generate_handoff, write_handoff,
     )
+    from tracker import format_ref
 
 
 def run_plan(
@@ -112,7 +114,7 @@ def run_plan(
         pp_out_file = str(state_dir.path / f"{prefix}_pp_out.txt")
         agent_call(
             "product-planner", 600,
-            f"@MODE:PLANNER:PRODUCT_PLAN\ncontext: {context} issue: #{issue_num}",
+            f"@MODE:PLANNER:PRODUCT_PLAN\ncontext: {context} issue: {format_ref(issue_num)}",
             pp_out_file, run_logger, config,
         )
         pp_out = Path(pp_out_file).read_text(encoding="utf-8", errors="replace")
@@ -180,7 +182,7 @@ def run_plan(
         pr_out_file = str(state_dir.path / f"{prefix}_plan_reviewer_out.txt")
         agent_call(
             "plan-reviewer", 600,
-            f"@MODE:REVIEWER:PLAN_REVIEW\nprd_path: {prd_path}\nissue: #{issue_num}",
+            f"@MODE:REVIEWER:PLAN_REVIEW\nprd_path: {prd_path}\nissue: {format_ref(issue_num)}",
             pr_out_file, run_logger, config,
         )
         _pr_cost = 0.0
@@ -293,13 +295,13 @@ def run_plan(
         if _uxa_mode == "UX_SYNC":
             _uxa_exit = agent_call(
                 "ux-architect", 600,
-                f"@MODE:UX_ARCHITECT:UX_SYNC\nprd_path: {prd_path}\nsrc_dir: src/\nissue: #{issue_num}",
+                f"@MODE:UX_ARCHITECT:UX_SYNC\nprd_path: {prd_path}\nsrc_dir: src/\nissue: {format_ref(issue_num)}",
                 uxa_out_file, run_logger, config,
             )
         else:
             _uxa_exit = agent_call(
                 "ux-architect", 600,
-                f"@MODE:UX_ARCHITECT:UX_FLOW\nprd_path: {prd_path}\nissue: #{issue_num}",
+                f"@MODE:UX_ARCHITECT:UX_FLOW\nprd_path: {prd_path}\nissue: {format_ref(issue_num)}",
                 uxa_out_file, run_logger, config,
             )
 
@@ -406,7 +408,7 @@ def run_plan(
         hud.log("UX_SKIP (UI 없는 기능)")
         print("[HARNESS] UX_SKIP -- UI 없는 기능, 설계 루프 직행")
         print(f"  prd_path: {prd_path or 'N/A'}")
-        print(f"  issue: #{issue_num}")
+        print(f"  issue: {format_ref(issue_num)}")
         run_logger.write_run_end("UX_SKIP", "", issue_num)
         return "UX_SKIP"
 
@@ -415,7 +417,7 @@ def run_plan(
     print("[HARNESS] UX_REVIEW_PASS")
     print(f"  prd_path: {prd_path or 'N/A'}")
     print(f"  ux_flow_doc: {ux_flow_doc or 'N/A'}")
-    print(f"  issue: #{issue_num}")
+    print(f"  issue: {format_ref(issue_num)}")
     print("  -> 유저 승인 1 대기 (PRD + UX Flow)")
     run_logger.write_run_end("UX_REVIEW_PASS", "", issue_num)
     return "UX_REVIEW_PASS"

--- a/harness/tracker.py
+++ b/harness/tracker.py
@@ -36,18 +36,40 @@ from typing import Optional, Protocol
 class IssueRef:
     backend: str       # "github" | "local"
     number: int
-    raw: str           # "#42" | "LOCAL-7"
+    raw: str           # "#42" | "LOCAL-7"  (display form)
 
     def __str__(self) -> str:
         return self.raw
 
+    @property
+    def internal(self) -> str:
+        """파일시스템·env·git branch 안전한 내부 표현.
 
-def parse_ref(s: str) -> IssueRef:
-    """추적 ID 문자열 파싱.
+        - github → 정수 문자열 ("42") — 디렉토리·flag·branch 명에 그대로 사용 가능
+        - local  → "LOCAL-7" (display form 과 동일 — 이미 안전한 형태)
 
-    수용 형식: "#42", "LOCAL-7", "42" (legacy GitHub)
+        display form (`raw`) 와의 차이는 github 케이스에서만 의미 있음:
+        `#42` 는 commit msg / PR title 용, `42` 는 dir/flag/branch 용.
+        """
+        if self.backend == "local":
+            return self.raw
+        return str(self.number)
+
+
+def parse_ref(s) -> IssueRef:
+    """추적 ID 파싱. str / int / IssueRef 모두 수용 (멱등).
+
+    수용 형식:
+      - "#42" → github
+      - "LOCAL-7" → local
+      - "42" 또는 42 → github (legacy 정수)
+      - IssueRef → 그대로 반환 (멱등성)
     """
-    s = s.strip()
+    if isinstance(s, IssueRef):
+        return s
+    if isinstance(s, int):
+        return IssueRef("github", s, f"#{s}")
+    s = (s or "").strip()
     if s.startswith("#") and s[1:].isdigit():
         return IssueRef("github", int(s[1:]), s)
     if s.startswith("LOCAL-") and s[6:].isdigit():
@@ -56,6 +78,30 @@ def parse_ref(s: str) -> IssueRef:
         n = int(s)
         return IssueRef("github", n, f"#{n}")
     raise ValueError(f"Unknown issue ref: {s!r}")
+
+
+def format_ref(s) -> str:
+    """Display form 반환 — commit msg / PR title 용.
+
+    "42" → "#42", "#42" → "#42", "LOCAL-7" → "LOCAL-7", IssueRef → ref.raw
+
+    빈 문자열·None 입력은 빈 문자열로 (caller 측 graceful 처리 위해).
+    """
+    if not s and s != 0:
+        return ""
+    return parse_ref(s).raw
+
+
+def normalize_issue_num(s) -> str:
+    """Internal form 반환 — 디렉토리·flag·git branch·env 용.
+
+    "42" → "42", "#42" → "42", "LOCAL-7" → "LOCAL-7", IssueRef → ref.internal
+
+    빈 문자열·None 은 빈 문자열로 (executor 진입 시 issue 미지정 케이스).
+    """
+    if not s and s != 0:
+        return ""
+    return parse_ref(s).internal
 
 
 # ── Backend Protocol ──

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -42,6 +42,7 @@
 | `HARNESS-CHG-20260428-01` | 2026-04-28 | agent | [1.5] agents/qa.md MCP 미가용 폴백 — Bash 추가 (tracker CLI 한정) + 폴백 흐름 안내 | — |
 | `HARNESS-CHG-20260428-01` | 2026-04-28 | spec  | [1.6] docs/harness-spec.md §3 I-2 추적 ID 일반형 표현 + harness-architecture.md §6 추적 백엔드 신규 섹션 | `Document-Exception: rationale.md 4섹션은 본 Task-ID 의 [1.2] commit 0c9d5f3 에서 일괄 작성됨 — 본 [1.6] 은 그 결정의 spec 적용` |
 | `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.1] tracker.py — IssueRef.internal property + format_ref() + normalize_issue_num() + 단위 테스트 33/33 | — |
+| `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.2] core.py 의 gh issue view → tracker.get_issue() 위임 + 7파일 f-string `#{issue_num}` → `{format_ref(issue_num)}` + executor 진입 normalize | — |
 
 ---
 

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -43,6 +43,7 @@
 | `HARNESS-CHG-20260428-01` | 2026-04-28 | spec  | [1.6] docs/harness-spec.md §3 I-2 추적 ID 일반형 표현 + harness-architecture.md §6 추적 백엔드 신규 섹션 | `Document-Exception: rationale.md 4섹션은 본 Task-ID 의 [1.2] commit 0c9d5f3 에서 일괄 작성됨 — 본 [1.6] 은 그 결정의 spec 적용` |
 | `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.1] tracker.py — IssueRef.internal property + format_ref() + normalize_issue_num() + 단위 테스트 33/33 | — |
 | `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.2] core.py 의 gh issue view → tracker.get_issue() 위임 + 7파일 f-string `#{issue_num}` → `{format_ref(issue_num)}` + executor 진입 normalize | — |
+| `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.3] smoke-test.sh §9 tracker LOCAL-N regression 회로 5건 추가 (parse_ref / format/normalize / LocalBackend 라운드트립 / 강제 폴백 / which CLI) — 56/56 PASS | — |
 
 ---
 

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -41,6 +41,7 @@
 | `HARNESS-CHG-20260428-01` | 2026-04-28 | agent | [1.4] agents/designer.md Phase 0-0 — gh issue create → tracker CLI + commit-gate.py Gate 1 가드 확장 | — |
 | `HARNESS-CHG-20260428-01` | 2026-04-28 | agent | [1.5] agents/qa.md MCP 미가용 폴백 — Bash 추가 (tracker CLI 한정) + 폴백 흐름 안내 | — |
 | `HARNESS-CHG-20260428-01` | 2026-04-28 | spec  | [1.6] docs/harness-spec.md §3 I-2 추적 ID 일반형 표현 + harness-architecture.md §6 추적 백엔드 신규 섹션 | `Document-Exception: rationale.md 4섹션은 본 Task-ID 의 [1.2] commit 0c9d5f3 에서 일괄 작성됨 — 본 [1.6] 은 그 결정의 spec 적용` |
+| `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.1] tracker.py — IssueRef.internal property + format_ref() + normalize_issue_num() + 단위 테스트 33/33 | — |
 
 ---
 

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -243,4 +243,27 @@
 
 ---
 
+## `HARNESS-CHG-20260428-02` — 2026-04-28 — 추적 ID 추상화 follow-up (잔존 흠 + 부수발견 수리)
+
+**Type**: infra (코드 + 테스트, spec 변경 없음)
+
+**Branch**: `harness/tracker-cleanup`
+
+**Issue**: 별도 추적 ID 미발급 — 직전 `HARNESS-CHG-20260428-01` (LOCAL-1) 의 자연 후속. 진단(2026-04-28) 시점에 유저 수리 지시 명시 ("잔존 홀이랑 부수발견 수리" + "1+2 후보도 같이 처리해줘" → smoke-test 통합)
+
+**Sub-commits**:
+- `[2.1]` `7a5a64f` `harness/tracker.py` (+50) — `IssueRef.internal` property + `format_ref()` + `normalize_issue_num()` + parse_ref 멱등 확장. `tests/pytest/test_tracker.py` (+60) 16→33 케이스
+- `[2.2]` `942cb7d` 7파일 정합 — `core.py` 의 `gh issue view` → `tracker.get_issue()` 위임 + f-string `#{issue_num}` → `{format_ref(issue_num)}` 일괄 교체 + executor 진입 `normalize_issue_num` 적용
+- `[2.3]` `0a31611` `scripts/smoke-test.sh` §9 신규 — tracker LOCAL-N regression 회로 5 케이스 (56/56 PASS)
+- `[2.4]` (본 commit) `rationale.md` 4섹션 + Task-ID 본문 + PR
+
+**Linked**:
+- `HARNESS-CHG-20260428-01` (commit `c18003e`) — 추적 ID 추상화 (이번 정리의 모태)
+- 진단 보고: 유저 세션 (2026-04-28) — "잔존 홀이랑 부수발견 수리"
+- `[2.2]` 검증: py_compile 8/8 + unittest 33/33 + smoke-test 56/56
+
+**Exception**: —
+
+---
+
 > 새 항목은 위 표 + 본 섹션 양쪽에 추가. Phase 2 자동 게이트가 활성화되면 표는 `scripts/check_doc_sync.py` 가 갱신 검증.

--- a/orchestration/rationale.md
+++ b/orchestration/rationale.md
@@ -385,4 +385,52 @@ gh CLI 미설치  →  GitHub Issue 번호(#N) 발급 불가
 
 ---
 
+## `HARNESS-CHG-20260428-02` — 2026-04-28
+
+### Rationale
+
+`HARNESS-CHG-20260428-01` 의 자연스러운 후속 — 추적 ID 추상화를 들이고 *남은* 두 흠과 한 부수발견 정리. 코어 워크플로우 영향은 없으나, LocalBackend 사용 시 다음 미관/일관성 흠이 드러남:
+
+1. `core.py:create_feature_branch` 가 직접 `gh issue view` 를 호출 → LOCAL-N 에선 silent fail → branch 슬러그가 빈 채로 `feat/LOCAL-7` 만 남음 (사람 읽기 슬러그 손실, 기능 차단은 아님)
+2. 다수 f-string `f"#{issue_num}"` 가 LOCAL-N 입력 시 `#LOCAL-7` 이중 prefix 출력 (commit msg / PR title / agent prompt 모두). 가독성 ↓.
+3. (부수발견) `--issue '#42'` 형태 입력 시 디렉토리·git branch 가 `#` 포함해 안전성 깨짐 — 호출자 어디도 그렇게 안 넘기지만 보호장치 부재.
+
+세 가지 모두 *기능 차단은 아니지만* 시스템 일관성 흠. 진단(2026-04-28) 시 유저가 *수리* 의지를 명시 → 이번 Task-ID 로 묶어 처리.
+
+### Alternatives
+
+| # | 옵션 | 평가 |
+|---|---|---|
+| 1 | 흠 무시, LocalBackend 미관 감수 | 거부 — 시스템 정체성(예측 가능성·일관성) 약화. 작은 흠이 누적되면 큰 부채 |
+| 2 | f-string 만 교체, gh→tracker 는 보류 | 거부 — 부분 작업. LocalBackend branch 슬러그 흠은 그대로 남음 |
+| **3** | **세 흠 일괄 수리 + smoke-test 회귀 회로 추가** | **선택** — 한 PR 안에서 일관성 회복, 자동 회귀 방어 |
+| 4 | tracker.py 에 백엔드 metadata 헬퍼 추가 (e.g., `format_ref` 를 IssueRef 메서드로) | 부분 채택 — `IssueRef.internal` property 만 채택. `format_ref` 는 module-level 함수로 (str/int/IssueRef 모두 수용 위해) |
+
+### Decision
+
+옵션 3 채택. 결정 항목:
+
+| 항목 | 값 | 근거 |
+|---|---|---|
+| 표현 분리 | `display form` ("#42" / "LOCAL-7") vs `internal form` ("42" / "LOCAL-7") | display = commit msg / PR title / agent prompt. internal = 디렉토리 / flag / git branch / env. 두 표현이 github 케이스에서만 차이 (`#42` vs `42`) — 이 차이가 부수발견의 원인 |
+| 헬퍼 형태 | `format_ref(s)` + `normalize_issue_num(s)` module-level 함수 | str/int/IssueRef 모두 수용. caller 다양성 수용 |
+| `IssueRef.internal` | property | dataclass 와 일관, 즉시 호출 |
+| `parse_ref` 멱등성 | IssueRef 입력 → 그대로 반환 | normalize 패턴에서 흔히 발생, 방어적 |
+| f-string 일괄 교체 | 7파일 30+곳 mechanical replace_all | 패턴이 매우 specific (`#{issue_num}` / `#{issue}`) — false match 위험 0 |
+| executor 진입 normalize | line 58 의 args parse 직후 | env / flag / dir 모든 다운스트림 의존이 여기서 시작. 한 곳만 normalize 하면 끝 |
+| smoke-test §9 추가 | 5 케이스 (parse_ref / format+normalize / LocalBackend 라운드트립 / 강제 폴백 / which) | tracker 회로 회귀 자동 감지. CI 무료 |
+
+### Follow-Up
+
+- `[2.1]` ✅ tracker.py 헬퍼 + 33/33 테스트 (commit `7a5a64f`)
+- `[2.2]` ✅ core/impl_loop/impl_router/plan_loop/helpers/notify/executor 7파일 정합 (commit `942cb7d`)
+- `[2.3]` ✅ smoke-test §9 tracker 회로 — 56/56 PASS (commit `0a31611`)
+- `[2.4]` 본 commit — rationale 4섹션 + PR 생성
+
+후속 별도 Task-ID 권장:
+- helpers.py:579 의 `f"Issue {format_ref(issue_num)} — `{impl_name}`\n"` 같은 PR body 가 GitHub 의 `Closes #N` 자동 클로즈 동작에 의존 — LocalBackend 에선 의미 없음. tracker 백엔드별 PR body 형식 분기 가능 (낮 우선)
+- worktree 격리 디렉토리 cleanup 시 LOCAL-N 디렉토리도 같은 라이프사이클인지 검증 (smoke-test §9 가 일부 cover)
+
+---
+
 > 새 항목은 위 형식으로 추가. Task-ID 헤더는 H2(`##`), 4섹션은 H3(`###`).

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -8,7 +8,7 @@
 #   CLAUDE_PLUGIN_ROOT=/path/to/plugin bash scripts/smoke-test.sh
 #     → 플러그인 모드 시뮬레이션
 #
-# 검증 항목 (10개):
+# 검증 항목 (11개):
 #  1. Python 파일 syntax (py_compile)
 #  2. hooks/hooks.json JSON 파싱
 #  3. .claude-plugin/{plugin,marketplace}.json 파싱
@@ -19,6 +19,7 @@
 #  8. setup-rwh.sh + scripts/hooks/pre-commit.sh syntax
 #  9. hooks/ 의 sys.path 트릭으로 harness_common 등 import 가능
 # 10. SKIP_DOC_SYNC env 우회 동작 (pre-commit.sh)
+# 11. tracker.py — parse_ref / format_ref / normalize / LocalBackend 회로 (LOCAL-N regression 방어)
 #
 # 종료 코드: 0 = ALL PASS / 1 = 1개 이상 FAIL
 set -u
@@ -152,6 +153,74 @@ mkdir -p scripts/hooks
 ln -sf $REPO_ROOT/scripts/hooks/pre-commit.sh scripts/hooks/pre-commit.sh
 SKIP_DOC_SYNC=1 bash scripts/hooks/pre-commit.sh 2>&1 | grep -q 'SKIP_DOC_SYNC=1' && echo OK
 "
+
+echo ""
+echo "[9] tracker.py — parse_ref / format_ref / normalize_issue_num"
+run "parse_ref 6 케이스 (#42 / LOCAL-7 / 42 / int / IssueRef 멱등 / 빈 입력 무시)" python3 -c "
+import sys; sys.path.insert(0, '.')
+from harness.tracker import parse_ref, format_ref, normalize_issue_num, IssueRef
+
+assert parse_ref('#42').raw == '#42' and parse_ref('#42').backend == 'github'
+assert parse_ref('LOCAL-7').raw == 'LOCAL-7' and parse_ref('LOCAL-7').backend == 'local'
+assert parse_ref('42').raw == '#42'
+assert parse_ref(42).raw == '#42'
+r = parse_ref('LOCAL-1')
+assert parse_ref(r) is r, '멱등 깨짐'
+print('OK: 5 케이스 통과')
+"
+
+run "format_ref / normalize 일관성 (디스플레이/내부 분리)" python3 -c "
+import sys; sys.path.insert(0, '.')
+from harness.tracker import format_ref, normalize_issue_num
+
+cases = [
+    ('42',      '#42',      '42'),
+    ('#42',     '#42',      '42'),       # 부수발견: 디렉토리 안전한 internal
+    ('LOCAL-7', 'LOCAL-7',  'LOCAL-7'),
+    (42,        '#42',      '42'),
+    ('',        '',         ''),
+    (None,      '',         ''),
+]
+for inp, exp_disp, exp_int in cases:
+    d = format_ref(inp)
+    n = normalize_issue_num(inp)
+    assert d == exp_disp, f'format_ref({inp!r}) = {d!r}, exp {exp_disp!r}'
+    assert n == exp_int, f'normalize({inp!r}) = {n!r}, exp {exp_int!r}'
+print(f'OK: {len(cases)} 케이스 모두 통과')
+"
+
+run "LocalBackend 라운드트립 (tmpdir create→get→comment)" python3 -c "
+import sys, tempfile
+from pathlib import Path
+sys.path.insert(0, '.')
+from harness.tracker import LocalBackend, IssueRef
+
+with tempfile.TemporaryDirectory() as tmp:
+    b = LocalBackend(root=Path(tmp))
+    r1 = b.create_issue('first', 'body1', ['bug'])
+    r2 = b.create_issue('second', 'body2')
+    assert r1.raw == 'LOCAL-1' and r2.raw == 'LOCAL-2'
+
+    e = b.get_issue(r1)
+    assert e['title'] == 'first' and e['labels'] == ['bug']
+
+    b.add_comment(r1, 'reviewed')
+    e2 = b.get_issue(r1)
+    assert len(e2['comments']) == 1 and e2['comments'][0]['body'] == 'reviewed'
+print('OK: create + get + comment 라운드트립')
+"
+
+run "HARNESS_TRACKER=local 강제 폴백 (gh 가용해도 local 선택)" python3 -c "
+import sys, os
+sys.path.insert(0, '.')
+os.environ['HARNESS_TRACKER'] = 'local'
+from harness.tracker import get_tracker
+b = get_tracker()
+assert b.name == 'local', f'expected local, got {b.name}'
+print('OK: HARNESS_TRACKER=local 우선')
+"
+
+run "tracker which CLI 출력 — selected 라인 + 두 백엔드 가용성" python3 -m harness.tracker which
 
 echo ""
 echo "==================================="

--- a/tests/pytest/test_tracker.py
+++ b/tests/pytest/test_tracker.py
@@ -91,6 +91,16 @@ class ParseRefTests(unittest.TestCase):
         self.assertEqual(r.backend, "github")
         self.assertEqual(r.raw, "#42")
 
+    def test_int_input(self):
+        r = tr.parse_ref(42)
+        self.assertEqual(r.backend, "github")
+        self.assertEqual(r.raw, "#42")
+
+    def test_idempotent_on_issue_ref(self):
+        r1 = tr.parse_ref("LOCAL-7")
+        r2 = tr.parse_ref(r1)
+        self.assertIs(r1, r2)
+
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             tr.parse_ref("xyz")
@@ -98,6 +108,72 @@ class ParseRefTests(unittest.TestCase):
     def test_invalid_local_format(self):
         with self.assertRaises(ValueError):
             tr.parse_ref("LOCAL-")
+
+
+class IssueRefInternalTests(unittest.TestCase):
+    """IssueRef.internal — 디렉토리·flag·branch·env 안전한 내부 표현."""
+
+    def test_github_internal_is_bare_number(self):
+        r = tr.parse_ref("#42")
+        self.assertEqual(r.internal, "42")
+
+    def test_local_internal_preserves_form(self):
+        r = tr.parse_ref("LOCAL-7")
+        self.assertEqual(r.internal, "LOCAL-7")
+
+    def test_github_legacy_internal(self):
+        r = tr.parse_ref("42")
+        self.assertEqual(r.internal, "42")
+
+
+class FormatRefTests(unittest.TestCase):
+    """format_ref — display form (commit msg, PR title)."""
+
+    def test_bare_number_to_hash(self):
+        self.assertEqual(tr.format_ref("42"), "#42")
+
+    def test_hash_idempotent(self):
+        self.assertEqual(tr.format_ref("#42"), "#42")
+
+    def test_local_unchanged(self):
+        self.assertEqual(tr.format_ref("LOCAL-7"), "LOCAL-7")
+
+    def test_int_input(self):
+        self.assertEqual(tr.format_ref(42), "#42")
+
+    def test_issue_ref_input(self):
+        ref = tr.IssueRef("local", 1, "LOCAL-1")
+        self.assertEqual(tr.format_ref(ref), "LOCAL-1")
+
+    def test_empty_is_empty(self):
+        self.assertEqual(tr.format_ref(""), "")
+        self.assertEqual(tr.format_ref(None), "")
+
+
+class NormalizeIssueNumTests(unittest.TestCase):
+    """normalize_issue_num — internal form (디렉토리·flag·branch)."""
+
+    def test_bare_number_unchanged(self):
+        self.assertEqual(tr.normalize_issue_num("42"), "42")
+
+    def test_strips_leading_hash(self):
+        # 부수발견 수리: "#42" → "42" — 디렉토리/branch 안전
+        self.assertEqual(tr.normalize_issue_num("#42"), "42")
+
+    def test_local_preserved(self):
+        self.assertEqual(tr.normalize_issue_num("LOCAL-7"), "LOCAL-7")
+
+    def test_int_input(self):
+        self.assertEqual(tr.normalize_issue_num(42), "42")
+
+    def test_issue_ref_input(self):
+        ref = tr.IssueRef("local", 1, "LOCAL-1")
+        self.assertEqual(tr.normalize_issue_num(ref), "LOCAL-1")
+
+    def test_empty_is_empty(self):
+        # executor 의 issue 미지정 케이스 — 빈 문자열 그대로
+        self.assertEqual(tr.normalize_issue_num(""), "")
+        self.assertEqual(tr.normalize_issue_num(None), "")
 
 
 class GetTrackerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `HARNESS-CHG-20260428-01` 의 자연스러운 후속. 코어 워크플로우 영향 없음.
- 두 흠 + 한 부수발견 일괄 수리 + smoke-test 회귀 회로 추가.

| 종류 | 위치 | 흠 | 수리 |
|---|---|---|---|
| 잔존 흠 1 | `core.py:create_feature_branch` | 직접 `gh issue view` → LocalBackend 미지원 → `feat/LOCAL-7` 슬러그 빈 채로 | `tracker.get_issue()` 1회 호출로 통합. 양쪽 백엔드에서 milestone/title 추출 |
| 잔존 흠 2 | 7파일 30+ 위치 | `f"#{issue_num}"` → LOCAL-N 입력 시 `#LOCAL-7` 이중 prefix | `{format_ref(issue_num)}` — github 만 `#`, local 은 `LOCAL-N` 그대로 |
| 부수발견 | executor 진입 + 다운스트림 | `--issue '#42'` 입력 시 디렉토리·branch 가 `#` 포함해 안전성 깨짐 | `normalize_issue_num()` — `"#42" → "42"` 정규화. `LOCAL-7` 보존 |

## 변경 요약

| 추가 | API | 용도 |
|---|---|---|
| `IssueRef.internal` (property) | github → `"42"`, local → `"LOCAL-7"` | 디렉토리·flag·branch·env 안전 internal form |
| `format_ref(s)` | github → `"#42"`, local → `"LOCAL-7"` | commit msg / PR title / agent prompt display form |
| `normalize_issue_num(s)` | `"#42"` → `"42"`, `"LOCAL-7"` 보존 | executor 진입 정규화 |
| `parse_ref` 확장 | str/int/IssueRef 모두 수용 (멱등) | caller 다양성 수용 |

## Sub-commits

| Sub | Commit | 변경 |
|---|---|---|
| [2.1] | `7a5a64f` | tracker.py + 단위 테스트 16→33 |
| [2.2] | `942cb7d` | 7파일 일괄 정합 (gh→tracker, f-string 교체, executor entry normalize) |
| [2.3] | `0a31611` | smoke-test.sh §9 — tracker LOCAL-N 회로 5건 |
| [2.4] | `21819fb` | rationale 4섹션 + Task-ID 본문 |

## Test plan

- [x] `python3 -m unittest tests.pytest.test_tracker` — 33/33 OK (이전 16, 신규 17: IssueRef.internal 3 / format_ref 6 / normalize 6 / parse_ref 확장 2)
- [x] `python3 -m py_compile` 8 파일 (core, impl_loop, impl_router, plan_loop, helpers, notify, executor, tracker) — syntax OK
- [x] `bash scripts/smoke-test.sh` — 56/56 PASS (이전 51 + 신규 §9 5건)
- [x] `python3 -m harness.tracker which` — selected: github / github: available / local: available
- [ ] e2e: `executor.py impl --issue LOCAL-N` 실제 실행 (별도 환경 권장)

## 호환성

- legacy `--issue 42` → 변화 없음 (display "#42")
- `--issue LOCAL-7` → 통과 (branch `feat/LOCAL-7-{slug}`, commit `Closes LOCAL-7`, worktree dir `.worktrees/proj/issue-LOCAL-7`)
- `--issue '#42'` → normalize 가 `"42"` 로 정규화 — 디렉토리/branch 안전 (회귀 보호)

## Linked

- 모태: `HARNESS-CHG-20260428-01` (commit `c18003e`, PR #1)
- 진단 보고: 유저 세션 (2026-04-28) — "잔존 홀이랑 부수발견 수리" + 후보 1+2 통합 지시
- rationale: `orchestration/rationale.md` `## HARNESS-CHG-20260428-02`

## Invariant impact

| 불변식 | 변경 | 평가 |
|---|---|---|
| §0 Core Invariant | 변경 없음 | 보존 |
| §3 I-1~I-9 | 변경 없음 | 보존 — 표현 일관성 정리만 |

`[invariant-shift]` 토큰 미포함 — 이번 PR 은 -01 의 *구현 일관성 보강* 이며 §3 I-2 의 의미 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)