### PR TITLE
HARNESS-CHG-20260428-04 executor.py 경로 hardcode 제거 (배포 차단 버그)

### DIFF
--- a/commands/init-rwh.md
+++ b/commands/init-rwh.md
@@ -103,7 +103,7 @@ CLAUDE.md 를 열어 [채우기] 표시된 항목을 이 프로젝트에 맞게 
 1. product-planner 에이전트와 대화해서 PRD/TRD 작성
 2. architect SYSTEM_DESIGN → 설계 문서 초안
 3. architect TASK_DECOMPOSE → 에픽 → backlog.md + stories.md 분해
-4. 구현 루프 실행 (python3 ~/.claude/harness/executor.py impl ...)
+4. 구현 루프 실행 (`python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl ...`)
 ```
 
 ---

--- a/commands/product-plan.md
+++ b/commands/product-plan.md
@@ -102,7 +102,7 @@ command: |
   PREFIX=$(python3 -c "import json,sys; d=json.load(open('.claude/harness.config.json')); print(d.get('prefix',''))" 2>/dev/null || echo "")
   PREFIX_ARGS=()
   [ -n "$PREFIX" ] && PREFIX_ARGS=(--prefix "$PREFIX")
-  python3 ~/.claude/harness/executor.py plan \
+  python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" plan \
     --context "[준비도 리포트 전문 + 5차원 수집 내용]" \
     "${PREFIX_ARGS[@]}"
 timeout: 3600000
@@ -120,7 +120,7 @@ plan 루프가 `CLARITY_INSUFFICIENT`를 반환하면 product-planner가 추가 
 4. plan 루프 재실행 (**timeout: 3600000 필수**):
    ```
    command: |
-     python3 ~/.claude/harness/executor.py plan \
+     python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" plan \
        --context "[갱신된 리포트 + 추가 답변 + PRD 초안: prd-draft.md]" \
        "${PREFIX_ARGS[@]}"
    timeout: 3600000
@@ -161,7 +161,7 @@ plan 루프가 `PLAN_REVIEW_CHANGES_REQUESTED`를 리턴하면 plan-reviewer(기
 context에는 reviewer 리포트의 "수정 요청 항목" 섹션을 포함:
 ```
 command: |
-  python3 ~/.claude/harness/executor.py plan \
+  python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" plan \
     --context "[plan-reviewer 리포트 수정 요청 항목 전문 + 이전 준비도 리포트]" \
     "${PREFIX_ARGS[@]}"
 timeout: 3600000
@@ -260,7 +260,7 @@ architect(SD) SYSTEM_DESIGN_READY + designer DESIGN_HANDOFF 완료 후:
 디자인 승인 후 구현 루프 진입. 상세: [orchestration/impl.md](../orchestration/impl.md)
 
 ```
-python3 ~/.claude/harness/executor.py impl \
+python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl \
   --impl <impl_path> \
   --issue <N> \
   "${PREFIX_ARGS[@]}"

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -89,7 +89,7 @@ QA 분석 결과에서 depth를 추천한다. 기준: **이 버그 수정이 기
 PREFIX=$(python3 -c "import json,sys; d=json.load(open('.claude/harness.config.json')); print(d.get('prefix',''))" 2>/dev/null || echo "")
 PREFIX_ARGS=()
 [ -n "$PREFIX" ] && PREFIX_ARGS=(--prefix "$PREFIX")
-python3 ~/.claude/harness/executor.py impl \
+python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl \
   --issue <QA가 생성한 이슈 번호> \
   --depth <simple|std|deep> \
   "${PREFIX_ARGS[@]}"
@@ -103,7 +103,7 @@ CLEANUP은 항상 `--depth simple`로 전달한다.
 PREFIX=$(python3 -c "import json,sys; d=json.load(open('.claude/harness.config.json')); print(d.get('prefix',''))" 2>/dev/null || echo "")
 PREFIX_ARGS=()
 [ -n "$PREFIX" ] && PREFIX_ARGS=(--prefix "$PREFIX")
-python3 ~/.claude/harness/executor.py impl \
+python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl \
   --issue <QA가 생성한 이슈 번호> \
   --depth simple \
   "${PREFIX_ARGS[@]}"

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -62,7 +62,7 @@ Bash 도구로 직접 실행. `timeout: 1800000` (30분) 필수.
 PREFIX=$(python3 -c "import json; d=json.load(open('.claude/harness.config.json')); print(d.get('prefix',''))" 2>/dev/null || echo "")
 PREFIX_ARGS=()
 [ -n "$PREFIX" ] && PREFIX_ARGS=(--prefix "$PREFIX")
-python3 ~/.claude/harness/executor.py impl \
+python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl \
   --issue <QA가 생성한 이슈 번호> \
   --depth simple \
   "${PREFIX_ARGS[@]}"

--- a/commands/ux.md
+++ b/commands/ux.md
@@ -311,7 +311,7 @@ DESIGN_HANDOFF 패키지의 `## Issue: #N`에서 이슈 번호를 읽고, 위에
 ```bash
 PREFIX_ARGS=()
 [ -n "$PREFIX" ] && PREFIX_ARGS=(--prefix "$PREFIX")
-python3 ~/.claude/harness/executor.py impl \
+python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl \
   --issue <DESIGN_HANDOFF의 Issue 번호> \
   --depth <simple|std|deep> \
   "${PREFIX_ARGS[@]}"

--- a/hooks/agent-gate.py
+++ b/hooks/agent-gate.py
@@ -98,8 +98,8 @@ def main():
     # 3. 하네스 내부 에이전트는 harness/executor.py 경유 필수
     if agent in HARNESS_ONLY_AGENTS and not flag(FLAGS.HARNESS_ACTIVE):
         cmds = {
-            "engineer": "python3 ~/.claude/harness/executor.py impl --impl <path> --issue <N>",
-            "architect": "python3 ~/.claude/harness/executor.py impl|plan ...",
+            "engineer": 'python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl --impl <path> --issue <REF>',
+            "architect": 'python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl|plan ...',
         }
         deny(f"❌ {agent}는 harness/executor.py를 통해서만 호출 가능. "
              f"{get_flags_dir()}/{PREFIX}_{FLAGS.HARNESS_ACTIVE} 없음. "
@@ -114,7 +114,7 @@ def main():
             if mode in ARCHITECT_HARNESS_ONLY_MODES:
                 deny(f"❌ architect {mode}는 harness/executor.py 경유만 허용됩니다. "
                      f"메인 Claude 직접 호출 금지. "
-                     f"→ python3 ~/.claude/harness/executor.py plan|impl --issue <N> ... "
+                     f'→ python3 "${{CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}}/harness/executor.py" plan|impl --issue <REF> ... '
                      f"(plan_loop/impl_loop가 내부에서 자동 호출)")
         elif agent == "validator":
             mode = detect_validator_mode(prompt)

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -45,6 +45,7 @@
 | `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.2] core.py 의 gh issue view → tracker.get_issue() 위임 + 7파일 f-string `#{issue_num}` → `{format_ref(issue_num)}` + executor 진입 normalize | — |
 | `HARNESS-CHG-20260428-02` | 2026-04-28 | infra | [2.3] smoke-test.sh §9 tracker LOCAL-N regression 회로 5건 추가 (parse_ref / format/normalize / LocalBackend 라운드트립 / 강제 폴백 / which CLI) — 56/56 PASS | — |
 | `HARNESS-CHG-20260428-03` | 2026-04-28 | infra | [3.1] BATS 잔존 표기 제거 — CHANGELOG 부채 라인 + PR 템플릿 + policies.md §2 `tests/bats/` 표기. 코드/스크립트에 BATS 흔적 0건 확인 (점검 결과) | — |
+| `HARNESS-CHG-20260428-04` | 2026-04-28 | infra | [4.1] `~/.claude/harness/executor.py` hardcode 제거 — 6 파일 13 위치 → `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py` (jajang 실제 사례에서 No such file or directory 발생) | — |
 
 ---
 
@@ -294,6 +295,52 @@
 **Linked**:
 - `CHANGELOG.md` v0.2.0 알려진 부채 §[6.2]
 - `HARNESS-CHG-20260427-06` rationale.md Follow-Up 의 `[6.2]` 항목
+
+**Exception**: —
+
+---
+
+## `HARNESS-CHG-20260428-04` — 2026-04-28 — executor.py 경로 hardcode 제거 (배포 차단 버그)
+
+**Type**: infra (commands + hooks)
+
+**Branch**: `harness/path-hardcode-fix`
+
+**Issue**: 별도 추적 ID 미발급 — 외부 사용자(jajang 프로젝트) 실측 사고 보고
+
+**증상 보고**: 사용자가 jajang 프로젝트에서 `/qa` 스킬 실행 → AI 가 deny 메시지의 hint 따라 `python3 ~/.claude/harness/executor.py ...` 시도 → `[Errno 2] No such file or directory: '/Users/dc.kim/.claude/harness/executor.py'`
+
+**원인**: Phase 4 [4.13] migrate-step2.sh 가 `~/.claude/harness/` 디렉토리 정리 후, 실제 executor.py 는 `~/.claude/plugins/marketplaces/realworld-harness/harness/executor.py` 에 설치됨. 그러나 다음 위치들의 user-facing 힌트는 *삭제된 경로* 를 그대로 가리킴:
+
+| 파일 | 위치 |
+|---|---|
+| `commands/quick.md` | line 65 |
+| `commands/qa.md` | lines 92, 106 |
+| `commands/ux.md` | line 314 |
+| `commands/init-rwh.md` | line 106 |
+| `commands/product-plan.md` | lines 105, 123, 164, 263 |
+| `hooks/agent-gate.py` | lines 101, 102, 117 (deny 메시지 dict + Mode-level deny) |
+| **합계** | **6 파일 13 위치** |
+
+**수정**: 모든 위치를 `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py` 형태로 일괄 교체:
+- 플러그인 install + Claude Code 세션: `CLAUDE_PLUGIN_ROOT` env 설정됨 → 그대로 사용
+- env 미설정 (수동 shell): 폴백 경로 = 실제 설치 위치
+- 기존 `~/.claude/harness/executor.py` 폴백은 *삭제* (post-migration 환경에서 무효)
+
+**검증**:
+- `bash scripts/smoke-test.sh` → 56/56 PASS (회귀 없음)
+- `python3 -m unittest tests.pytest.test_tracker` → 33/33 OK
+- `grep -rn '~/.claude/harness/executor.py' commands/ hooks/` → 0 잔존
+
+**비변경**:
+- `harness/executor.py` 자체의 `PLUGIN_ROOT` 폴백 (line 20) — 코드 내부에서 path 해석에 사용. user-facing hint 와 별개. 이번 PR 범위 밖
+- `orchestration/upstream/*` historical entries — 보존
+- `scripts/setup-rwh.sh:166` — 마이그레이션 정리 로직, user-facing 아님
+
+**Linked**:
+- 외부 사용자 보고 (2026-04-28): jajang 프로젝트에서 발생
+- Phase 4 [4.13] migrate-step2.sh — 원인이 된 마이그레이션
+- 후속: `HARNESS-CHG-20260428-05` (예정) — architect 마커 미감지 → SPEC_GAP_ESCALATE 진단·수정 (별도 Task-ID)
 
 **Exception**: —
 


### PR DESCRIPTION
## Summary

- **외부 사용자 실측 사고** — jajang 프로젝트에서 `/qa` 스킬 실행 시 deny 메시지 힌트의 `~/.claude/harness/executor.py` 가 *마이그레이션으로 삭제된 경로* 라 `[Errno 2] No such file or directory` 발생.
- 6 파일 13 위치 일괄 교체. 외부 사용자 첫 진입 시 즉시 좌절시키는 배포 차단 버그.

## 원인 체인

1. Phase 4 [4.13] `migrate-step2.sh` 가 `~/.claude/harness/` 정리
2. 실제 executor.py 는 `~/.claude/plugins/marketplaces/realworld-harness/harness/executor.py` 로 이동
3. user-facing 힌트(deny 메시지 + commands/*.md) 는 *삭제된 경로* 그대로 가리킴
4. AI/사용자가 힌트 따라 실행 → No such file → 좌절

## 수정 (6 파일 13 위치)

| 파일 | 위치 |
|---|---|
| `commands/quick.md` | line 65 |
| `commands/qa.md` | lines 92, 106 |
| `commands/ux.md` | line 314 |
| `commands/init-rwh.md` | line 106 |
| `commands/product-plan.md` | lines 105, 123, 164, 263 |
| `hooks/agent-gate.py` | lines 101, 102, 117 (deny dict + Mode-level deny) |

`~/.claude/harness/executor.py` → `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py`

**폴백 동작**:
- 플러그인 install + Claude Code 세션: `CLAUDE_PLUGIN_ROOT` env 설정됨 → 그대로 사용 ✓
- env 미설정 (수동 shell): 폴백 = 실제 marketplace 설치 위치 ✓
- 기존 `~/.claude/harness/...` 폴백 *삭제* (post-migration 무효 경로)

## Test plan

- [x] `grep -rn '~/.claude/harness/executor.py' commands/ hooks/` → 0 잔존
- [x] `bash scripts/smoke-test.sh` → 56/56 PASS (회귀 없음)
- [x] `python3 -m unittest tests.pytest.test_tracker` → 33/33 OK
- [ ] e2e: 새 jajang 세션에서 `/qa` 스킬 재현 — 별도 환경 검증

## 비변경 (의도)

- `harness/executor.py` 자체의 `PLUGIN_ROOT` 폴백 (line 20) — 코드 내부 path 해석용, user-facing 아님 (별도)
- `orchestration/upstream/*` historical entries — 보존
- `scripts/setup-rwh.sh:166` — 마이그레이션 정리 로직

## 후속

- `HARNESS-CHG-20260428-05` (예정) — architect 마커 미감지 → SPEC_GAP_ESCALATE 진단·수정. 같은 jajang 사례에서 발견된 *별개* strict 지점

## Linked

- 외부 사용자 보고: 2026-04-28 jajang 세션 transcript
- Phase 4 [4.13] `migrate-step2.sh` — 원인이 된 마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)