### PR TITLE
HARNESS-CHG-20260428-06 프로세스 복구 가시성 + AI 패닉 회로 차단 (B-3)

### DIFF
--- a/harness/executor.py
+++ b/harness/executor.py
@@ -138,9 +138,17 @@ def main() -> None:
                     print("동시 실행은 지원하지 않습니다. /harness-kill로 기존 실행을 중단하거나 완료를 기다리세요.")
                     sys.exit(1)
                 except OSError:
-                    # PID 죽었음 — stale lock 정리
+                    # PID 죽었음 — stale lock 정리. 외부 SIGKILL/세션 종료 후 재진입 케이스.
+                    # 상태 추적 가시성 (HARNESS-CHG-20260428-06): 이전엔 silent unlink 라
+                    # AI 가 "왜 막혀있지?" 패닉으로 우회 시도 → 본 메시지로 정상 복구임을 명시.
+                    _started = data.get("started", 0)
+                    _hb = data.get("heartbeat", 0)
+                    _stale_secs = int(time.time()) - max(_started, _hb)
+                    print(f"[HARNESS] 직전 실행 PID={existing_pid} 죽음 — stale lock 자동 정리 "
+                          f"(마지막 heartbeat {_stale_secs}초 전). 재진행합니다.")
                     lock_file.unlink(missing_ok=True)
         except (json.JSONDecodeError, OSError):
+            print(f"[HARNESS] lock 파일 손상 — 자동 정리 후 재진행: {lock_file}")
             lock_file.unlink(missing_ok=True)
 
     lock_started = int(time.time())

--- a/hooks/agent-gate.py
+++ b/hooks/agent-gate.py
@@ -101,9 +101,18 @@ def main():
             "engineer": 'python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl --impl <path> --issue <REF>',
             "architect": 'python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py" impl|plan ...',
         }
-        deny(f"❌ {agent}는 harness/executor.py를 통해서만 호출 가능. "
-             f"{get_flags_dir()}/{PREFIX}_{FLAGS.HARNESS_ACTIVE} 없음. "
-             f"직접 호출 금지 → {cmds.get(agent, 'executor.py')}")
+        deny(
+            f"❌ {agent}는 harness/executor.py를 통해서만 호출 가능. "
+            f"{get_flags_dir()}/{PREFIX}_{FLAGS.HARNESS_ACTIVE} 없음. "
+            f"직접 호출 금지 → {cmds.get(agent, 'executor.py')}\n"
+            "\n"
+            "🚫 패닉 회로 — 직전에 executor 가 SPEC_GAP_ESCALATE / 무진전 / 외부 종료\n"
+            "   등으로 멈췄다고 해서 이 에이전트를 직접 부르지 마라. 우회 시도는\n"
+            "   상태 추적 붕괴 + I-2 위반이다. 대신:\n"
+            "   1. executor.py 재실행 (`--force-retry` 옵션으로 cooldown 우회 가능)\n"
+            "   2. 새 셸/세션 (stale 상태 자동 복구 — HARNESS-CHG-20260428-06)\n"
+            "   3. 그래도 막히면 유저 보고 — 메인 Claude 영역 아님."
+        )
 
     # 3a. Mode-level 게이트 — architect/validator 세분화
     #     product-plan 스킬 6단계처럼 SYSTEM_DESIGN은 메인 Claude 직접 호출 허용이지만,

--- a/hooks/plugin-write-guard.py
+++ b/hooks/plugin-write-guard.py
@@ -68,10 +68,20 @@ def main() -> None:
                 f"[plugin-write-guard] 플러그인 디렉토리 직접 수정 금지: {fp}\n"
                 "CC 플러그인 매니저가 관리하는 영역입니다. 재설치 시 변경이 증발하거나\n"
                 "원본과 drift가 생겨 추적 불가능한 오염을 만듭니다.\n"
+                "\n"
+                "🚫 패닉 회로 — 하네스 루프(executor.py) 가 멈춰서 여기로 흘러왔다면 절대\n"
+                "   plugin/hooks/agents 를 inspect/edit 으로 우회하지 마라. 막힌 원인은\n"
+                "   인프라가 *건드려야 풀리는* 게 아니라 *재시작해야 풀리는* 종류다.\n"
+                "   대신:\n"
+                "   1. 새 셸/세션에서 executor.py 재실행 (상태 stale 자동 복구 — HARNESS-CHG-20260428-06)\n"
+                "   2. `--force-retry` 플래그로 cooldown 우회\n"
+                "   3. 그래도 막히면 유저에게 보고 — 메인 Claude 의 영역이 아님\n"
+                "\n"
+                "정상 경로:\n"
                 "- 커스텀 스킬/커맨드는 ~/.claude/commands/*.md 에 두세요.\n"
                 "- 에이전트 프로젝트 컨텍스트는 .claude/agent-config/*.md 에 두세요.\n"
                 "- 오피셜 플러그인 버그는 선행 훅(~/.claude/hooks/*.py)으로 우회하세요.\n"
-                f"- 정말 필요하면 {ALLOW_ENV}=1 환경 변수로 일시 허용."
+                f"- 정말 필요하면: export {ALLOW_ENV}=1 후 같은 세션에서 재시도."
             )
 
 

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -48,6 +48,8 @@
 | `HARNESS-CHG-20260428-04` | 2026-04-28 | infra | [4.1] `~/.claude/harness/executor.py` hardcode 제거 — 6 파일 13 위치 → `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/executor.py` (jajang 실제 사례에서 No such file or directory 발생) | — |
 | `HARNESS-CHG-20260428-05` | 2026-04-28 | infra | [5.1] `diagnose_marker_miss()` 헬퍼 + 9 사이트 적용 (impl_router 2 + plan_loop 1 + core 6 validator) — 마커 미감지 시 arch_out 마지막 500자 진단 로그 | — |
 | `HARNESS-CHG-20260428-05` | 2026-04-28 | agent | [5.2] architect sub-docs 출력 형식 canonical — light-plan/module-plan/task-decompose `---MARKER:X---` 정형 마커로 통일 + preamble 자가-체크 룰 추가 | — |
+| `HARNESS-CHG-20260428-06` | 2026-04-28 | infra | [6.1] AI 패닉 회로 차단 — agent-gate.py + plugin-write-guard.py deny 메시지에 명시적 복구 가이드 (executor 재실행 / 새 세션 / 유저 보고 — 인프라 inspect/edit 금지) | — |
+| `HARNESS-CHG-20260428-06` | 2026-04-28 | infra | [6.2] executor.py stale lock 자동 정리 visibility — silent unlink → 명시적 메시지 ("직전 실행 PID=X 죽음, 재진행합니다") | — |
 
 ---
 
@@ -393,6 +395,51 @@
 - jajang 사용자 사례 (2026-04-28) — `executor.py` 두 번째 시도 후 SPEC_GAP_ESCALATE
 - `HARNESS-CHG-20260428-04` (PR #4) — 같은 사례의 첫 단계 (path hardcode) 해소
 - 후속: `HARNESS-CHG-20260428-06` (예정) — 프로세스 hung/crashed 복구 가시성 (B-3)
+
+**Exception**: —
+
+---
+
+## `HARNESS-CHG-20260428-06` — 2026-04-28 — 프로세스 hung/crashed 복구 가시성 (B-3)
+
+**Type**: infra (hooks + executor)
+
+**Branch**: `harness/recovery-visibility`
+
+**Issue**: jajang 사례 — executor 가 validator agent_start 직후 외부 종료(SIGKILL/세션 disconnect 추정). AI 가 *복구 경로 안내 없음* + *stale state silent recovery* 때문에 패닉 → engineer 직접 호출 시도 (HARNESS_ONLY_AGENTS 차단) → 인프라 파일 inspect/edit 시도 (plugin-write-guard 차단) → 유저 좌절 ("니가 인프라를 왜 건들어").
+
+**현 시스템 분석**:
+- executor.py 의 lock 파일 PID 검사 + 자동 정리 로직은 *이미 작동* (line 130-144)
+- 외부 SIGKILL 후 재진입 시 자동 복구 가능
+- 그러나 정리가 *silent* — AI 는 막힌 게 풀린 줄 모름
+- HARNESS_ONLY_AGENTS / plugin-write-guard 차단도 *대안 안내 없음* — AI 가 다른 우회 시도
+
+**[6.1] 패닉 회로 차단 (3 deny 메시지)**:
+- `hooks/agent-gate.py` HARNESS_ONLY_AGENTS deny — "🚫 패닉 회로" 섹션 추가:
+  1. executor.py 재실행 (`--force-retry` 옵션으로 cooldown 우회)
+  2. 새 셸/세션 (stale 상태 자동 복구)
+  3. 그래도 막히면 유저 보고 — 메인 Claude 영역 아님
+- `hooks/plugin-write-guard.py` deny — 동일 패턴 + 정상 경로 안내 (커스텀 스킬은 ~/.claude/commands/, 에이전트 컨텍스트는 .claude/agent-config/, 우회 필요시 `export CLAUDE_ALLOW_PLUGIN_EDIT=1`)
+
+**[6.2] stale lock 가시성**:
+- `harness/executor.py:130-144` lock 파일 PID 검사 결과 죽은 PID → 기존: `lock_file.unlink(missing_ok=True)` silent. 신규: `print("[HARNESS] 직전 실행 PID=X 죽음 — stale lock 자동 정리 (마지막 heartbeat N초 전). 재진행합니다.")`
+- 손상된 lock 파일도 동일 — silent → 명시 메시지
+
+**비변경 (의도)**:
+- `agent_call` watchdog 자체 — 이미 timeout 시 subprocess.terminate + kill. 정상 동작
+- atexit + SIGTERM/SIGINT 핸들러 — 이미 cleanup 등록. 정상 동작
+- 이슈 lock heartbeat — 이미 존재. 별도 추가 불필요
+
+**검증**:
+- python3 -m py_compile harness/executor.py hooks/agent-gate.py hooks/plugin-write-guard.py — OK
+- bash scripts/smoke-test.sh — 56/56 PASS (회귀 없음)
+- python3 -m unittest tests.pytest.test_tracker — 33/33 OK
+
+**Linked**:
+- jajang 사례 (2026-04-28): "니가 인프라를 왜 건들어" 유저 차단
+- `HARNESS-CHG-20260428-04` (PR #4): 같은 사례 1단계 (path)
+- `HARNESS-CHG-20260428-05` (PR #5): 같은 사례 2단계 (marker)
+- 본 PR: 같은 사례 3단계 (process recovery panic)
 
 **Exception**: —
 


### PR DESCRIPTION
## Summary

jajang 사례 — executor 외부 종료 후 AI 가 *복구 경로 안내 부재* + *stale state silent recovery* 때문에 패닉. 결과: engineer 직접 호출 시도 (HARNESS_ONLY_AGENTS 차단) → 인프라 inspect/edit 시도 (plugin-write-guard 차단) → 유저 좌절 ("니가 인프라를 왜 건들어").

두 층 패치 — 사용자 보호 가드는 보존, AI 가 *알아서 정상 경로로 돌아갈 수 있게* 가시성 + 가이드 추가.

## [6.1] 패닉 회로 차단

**hooks/agent-gate.py** HARNESS_ONLY_AGENTS deny — "🚫 패닉 회로" 섹션 추가:

```
직전에 executor 가 SPEC_GAP_ESCALATE / 무진전 / 외부 종료 등으로 멈췄다고
이 에이전트를 직접 부르지 마라. 우회는 상태 추적 붕괴 + I-2 위반.
대신:
1. executor.py 재실행 (`--force-retry` cooldown 우회 가능)
2. 새 셸/세션 (stale 상태 자동 복구 — HARNESS-CHG-20260428-06)
3. 그래도 막히면 유저 보고 — 메인 Claude 영역 아님.
```

**hooks/plugin-write-guard.py** — 동일 패턴 + `export CLAUDE_ALLOW_PLUGIN_EDIT=1` 사용법 명확화

## [6.2] stale lock 가시성

**harness/executor.py:130-144** — PID 검사 + 자동 복구 로직 자체는 *이미 작동*. 정리가 silent → 명시 메시지로:

```
[HARNESS] 직전 실행 PID=X 죽음 — stale lock 자동 정리
(마지막 heartbeat N초 전). 재진행합니다.
```

손상된 lock 파일 케이스도 동일 처리.

## 비변경 (의도)

- `agent_call` watchdog 자체 — timeout 시 terminate+kill 이미 동작
- `atexit` + `SIGTERM`/`SIGINT` 핸들러 — cleanup 이미 등록
- 이슈 lock heartbeat — 이미 존재

본 PR 의 가치는 *기존 복구 메커니즘이 작동했음을 AI 에게 알리는 것*.

## Test plan

- [x] `python3 -m py_compile harness/executor.py hooks/agent-gate.py hooks/plugin-write-guard.py` — OK
- [x] `bash scripts/smoke-test.sh` — 56/56 PASS
- [x] `python3 -m unittest tests.pytest.test_tracker` — 33/33 OK
- [ ] e2e: jajang 같은 환경에서 executor 외부 SIGKILL → 재진입 시 deny 메시지 + stale 정리 메시지 확인 (별도)

## jajang 사례 종결

| 단계 | 증상 | 패치 |
|---|---|---|
| 1 | `python3 ~/.claude/harness/executor.py` → No such file | `HARNESS-CHG-20260428-04` (PR #4) |
| 2 | architect 마커 미감지 → `SPEC_GAP_ESCALATE (UNKNOWN)` | `HARNESS-CHG-20260428-05` (PR #5) |
| 3 | executor 외부 종료 → AI 패닉 → 인프라 우회 | **본 PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)