### PR TITLE
HARNESS-CHG-20260428-09 parse_marker alias map (LLM 변형 흡수)

### DIFF
--- a/harness/core.py
+++ b/harness/core.py
@@ -520,6 +520,55 @@ def diagnose_marker_miss(out_file: str | Path, expected: str) -> str:
             f"[DIAG] 마지막 {tail_n}자:\n---\n{tail}\n---")
 
 
+# ── Marker alias map — LLM 변형 흡수 (defense in depth) ──
+#
+# 에이전트 docs 가 canonical 마커를 강제해도 LLM 이 변형을 emit 하는 사례 존재
+# (실측: jajang 2026-04-28 — validator 가 PLAN_LGTM / PLAN_OK / APPROVE 변형 emit).
+# agent docs 강화는 *주 방어선*, alias map 은 *defense in depth* — agent docs 가
+# 약화·LLM rebellion 발생해도 워크플로우 정지 안 되도록.
+#
+# 룰: 키 = 변형 (LLM emit 가능), 값 = canonical (parse_marker 호출자가 기대)
+# 이 매핑은 parse_marker 가 1차/2차 매치 실패 시 3차 fallback 으로 적용.
+MARKER_ALIASES = {
+    # PLAN_VALIDATION
+    "PLAN_LGTM": "PLAN_VALIDATION_PASS",
+    "PLAN_OK": "PLAN_VALIDATION_PASS",
+    "PLAN_APPROVE": "PLAN_VALIDATION_PASS",
+    "PLAN_APPROVED": "PLAN_VALIDATION_PASS",
+    "PLAN_REJECT": "PLAN_VALIDATION_FAIL",
+    "PLAN_REJECTED": "PLAN_VALIDATION_FAIL",
+    "PLAN_NOT_APPROVED": "PLAN_VALIDATION_FAIL",
+    # DESIGN_VALIDATION
+    "DESIGN_LGTM": "DESIGN_REVIEW_PASS",
+    "DESIGN_OK": "DESIGN_REVIEW_PASS",
+    "DESIGN_APPROVE": "DESIGN_REVIEW_PASS",
+    "DESIGN_APPROVED": "DESIGN_REVIEW_PASS",
+    "DESIGN_REJECT": "DESIGN_REVIEW_FAIL",
+    "DESIGN_REJECTED": "DESIGN_REVIEW_FAIL",
+    # BUGFIX_VALIDATION
+    "BUGFIX_LGTM": "BUGFIX_PASS",
+    "BUGFIX_OK": "BUGFIX_PASS",
+    "BUGFIX_APPROVE": "BUGFIX_PASS",
+    # UX_VALIDATION
+    "UX_LGTM": "UX_REVIEW_PASS",
+    "UX_OK": "UX_REVIEW_PASS",
+    "UX_APPROVE": "UX_REVIEW_PASS",
+    "UX_REJECT": "UX_REVIEW_FAIL",
+    # CODE_VALIDATION (이미 PASS/FAIL 캐노니컬과 충돌 없음)
+    "CODE_LGTM": "PASS",
+    "CODE_OK": "PASS",
+    "CODE_APPROVE": "PASS",
+    # 일반 (알리아스 컬렉션 — 호출자 expected set 안 일 때만 매핑)
+    "APPROVE": "PASS",
+    "APPROVED": "PASS",
+    "OK": "PASS",
+    "REJECT": "FAIL",
+    "REJECTED": "FAIL",
+    "NOT_APPROVED": "FAIL",
+    # 주의: LGTM 단독은 alias 안 함 — pr-reviewer 의 정식 마커이기도 해서 충돌
+}
+
+
 def parse_marker(filepath: str | Path, patterns: str) -> str:
     """에이전트 출력 파일에서 마커를 파싱.
 
@@ -528,7 +577,15 @@ def parse_marker(filepath: str | Path, patterns: str) -> str:
         patterns: 파이프 구분 마커 목록 (e.g. "PASS|FAIL|SPEC_MISSING")
 
     Returns:
-        매칭된 마커 문자열, 없으면 "UNKNOWN"
+        매칭된 마커 문자열 (canonical), 없으면 "UNKNOWN"
+
+    매칭 단계:
+      1차: 구조화된 마커 `---MARKER:X---` (X ∈ patterns)
+      2차: 워드 바운더리 `\\bX\\b` (legacy 폴백)
+      3차: alias map 변형 → canonical 으로 normalize 후 patterns 안에 있으면 반환
+            (LLM 변형 흡수 — defense in depth, jajang 2026-04-28 사고 후속)
+
+    3차에서 alias hit 시 stderr 로 경고 — agent docs 강화 필요 신호.
     """
     try:
         content = Path(filepath).read_text(encoding="utf-8", errors="replace")
@@ -536,6 +593,7 @@ def parse_marker(filepath: str | Path, patterns: str) -> str:
         return "UNKNOWN"
 
     pattern_list = patterns.split("|")
+    expected_set = set(pattern_list)
     joined = "|".join(re.escape(p) for p in pattern_list)
 
     # 1차: 구조화된 마커 ---MARKER:X---
@@ -547,6 +605,22 @@ def parse_marker(filepath: str | Path, patterns: str) -> str:
     m = re.search(rf"\b({joined})\b", content)
     if m:
         return m.group(1)
+
+    # 3차 폴백: alias map — LLM 변형 흡수
+    # canonical 도 ---MARKER:X--- 형태로 emit 가능, 또는 평이 단어
+    alias_keys = "|".join(re.escape(k) for k in MARKER_ALIASES)
+    if alias_keys:
+        m = re.search(rf"---MARKER:({alias_keys})---", content) \
+            or re.search(rf"\b({alias_keys})\b", content)
+        if m:
+            variant = m.group(1)
+            canonical = MARKER_ALIASES[variant]
+            if canonical in expected_set:
+                sys.stderr.write(
+                    f"[parse_marker] alias hit — '{variant}' → '{canonical}' "
+                    f"(agent docs canonical 룰 강화 권장)\n"
+                )
+                return canonical
 
     return "UNKNOWN"
 

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -52,6 +52,7 @@
 | `HARNESS-CHG-20260428-06` | 2026-04-28 | infra | [6.2] executor.py stale lock 자동 정리 visibility — silent unlink → 명시적 메시지 ("직전 실행 PID=X 죽음, 재진행합니다") | — |
 | `HARNESS-CHG-20260428-07` | 2026-04-28 | infra | [7.1] migration audit — `~/.claude/scripts/`, `~/.claude/setup-harness.sh`, `~/.claude/agents/{agent}.md` 잔존 hardcode 5 파일 9 위치 일괄 env-aware 교체 (PR #4 systematic 후속) | `Document-Exception: harness-architecture.md 단일 행 path 정정 — 의사결정 변경 없는 문구 fix 라 rationale 4섹션 불필요. 본 Task-ID 본문 섹션이 동기·범위 명시` |
 | `HARNESS-CHG-20260428-08` | 2026-04-28 | agent | [8.1] validator sub-docs canonical 마커 — plan/code/design/bugfix-validation 출력 형식 `---MARKER:X---` 정형화 + preamble 마커명 정확도 절대 룰 추가 (PLAN_LGTM 변형 차단) | — |
+| `HARNESS-CHG-20260428-09` | 2026-04-28 | infra | [9.1] parse_marker alias map — LLM 변형(PLAN_LGTM/PLAN_OK/PLAN_APPROVE/APPROVE/REJECT 등) → canonical 흡수. 3차 폴백 + stderr 경고. agent docs 강화로 안 풀린 PLAN_OK/APPROVE 사례(jajang 2026-04-28) defense in depth | — |
 
 ---
 
@@ -541,6 +542,54 @@ RWHarness commands/harness-review.md:21 → ~/.claude/scripts/harness-review.py 
 - jajang 사용자 사례 (2026-04-28): validator PLAN_LGTM emit
 - 업스트림 검증: `gh api repos/alruminum/ClaudeCodeAgentPrompt` — 업스트림에도 같은 fragility 존재
 - `HARNESS-CHG-20260428-05` (PR #5) — architect canonical 마커. 본 PR 은 validator 영역 동일 패턴
+
+**Exception**: —
+
+---
+
+## `HARNESS-CHG-20260428-09` — 2026-04-28 — parse_marker alias map (LLM 변형 흡수)
+
+**Type**: infra (harness/core.py + tests)
+
+**Branch**: `harness/marker-alias-map`
+
+**Issue**: PR #8 의 canonical 마커 + preamble 절대 룰이 *이미 적용된 상태* (jajang 의 plugin cache 가 RWHarness main 으로 symlink — dev 모드, 변경 즉시 live) 에서도 validator 가 `PLAN_OK` / `APPROVE` 변형 emit → `parse_marker → UNKNOWN` → `PLAN_VALIDATION_ESCALATE` 또 발생.
+
+**근본 원인**: agent docs 강화는 *주 방어선* 이지만 LLM 이 룰 따르지 않는 사례 존재. agent docs 만 의지하는 건 fragile — *defense in depth* 필요.
+
+**[9.1] alias map**:
+- `harness/core.py:523-580` — `MARKER_ALIASES` dict 신규
+  - 변형 키 → canonical 값 (호출자 expected set 안 일 때만 normalize)
+  - PLAN_LGTM / PLAN_OK / PLAN_APPROVE / PLAN_APPROVED → PLAN_VALIDATION_PASS
+  - PLAN_REJECT / PLAN_REJECTED / PLAN_NOT_APPROVED → PLAN_VALIDATION_FAIL
+  - DESIGN_LGTM / DESIGN_OK / DESIGN_APPROVE → DESIGN_REVIEW_PASS
+  - DESIGN_REJECT / DESIGN_REJECTED → DESIGN_REVIEW_FAIL
+  - BUGFIX_LGTM / BUGFIX_OK / BUGFIX_APPROVE → BUGFIX_PASS
+  - UX_LGTM / UX_OK / UX_APPROVE → UX_REVIEW_PASS, UX_REJECT → UX_REVIEW_FAIL
+  - CODE_LGTM / CODE_OK / CODE_APPROVE → PASS
+  - 일반: APPROVE/APPROVED/OK → PASS, REJECT/REJECTED/NOT_APPROVED → FAIL
+
+- `parse_marker` 3차 폴백 로직 추가:
+  1차 `---MARKER:X---` (canonical 정형) → 매치 시 그대로
+  2차 `\bX\b` (canonical 워드 바운더리) → 매치 시 그대로
+  3차 alias map 의 변형이 ---MARKER 또는 워드 바운더리로 출현 + 그 canonical 이 호출자 expected set 안 → normalize 해서 반환 + stderr 경고
+
+- stderr 경고: "alias hit — 'PLAN_OK' → 'PLAN_VALIDATION_PASS' (agent docs canonical 룰 강화 권장)" — 발생 시 agent docs 보강 시그널
+
+**보존 (false positive 차단)**:
+- LGTM 단독 매핑 안 함 — pr-reviewer 의 정식 마커이기도 해서 충돌
+- alias 는 호출자가 *해당 canonical 을 expected set 에 포함* 시킬 때만 적용. 다른 컨텍스트의 alias 차용 차단
+- canonical 이 같은 파일에 있으면 1차/2차 우선 (alias 는 마지막 폴백)
+
+**검증**:
+- `tests/pytest/test_tracker.py` ParseMarkerAliasTests 11 케이스 신규
+  - canonical 우선 / alias 정상 normalize / 다른 컨텍스트 거부 / unknown 보존
+- 33→44 케이스. 100% 통과.
+- bash scripts/smoke-test.sh — 56/56 (회귀 없음)
+
+**Linked**:
+- jajang 사례 (2026-04-28) `PLAN_OK / APPROVE` 변형 emit
+- `HARNESS-CHG-20260428-08` (PR #8) — agent docs canonical 룰. *주 방어선*. 본 PR 은 *defense in depth* 보완
 
 **Exception**: —
 

--- a/tests/pytest/test_tracker.py
+++ b/tests/pytest/test_tracker.py
@@ -218,5 +218,97 @@ class GitHubBackendDetectionTests(unittest.TestCase):
             _sh.which = original
 
 
+class ParseMarkerAliasTests(unittest.TestCase):
+    """parse_marker alias map — LLM 변형 흡수 (defense in depth)."""
+
+    def setUp(self):
+        from harness import core as _core  # noqa: E402
+        self.core = _core
+        self.tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False, encoding="utf-8"
+        )
+
+    def tearDown(self):
+        import os as _os
+        try:
+            _os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def _write(self, content: str):
+        self.tmp.write(content)
+        self.tmp.flush()
+        self.tmp.close()
+
+    def test_canonical_marker_still_works(self):
+        self._write("preamble\n---MARKER:PLAN_VALIDATION_PASS---\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL")
+        self.assertEqual(r, "PLAN_VALIDATION_PASS")
+
+    def test_alias_plan_lgtm_to_canonical(self):
+        # jajang 2026-04-28 실측 사례
+        self._write("validator output...\nPLAN_LGTM\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
+        self.assertEqual(r, "PLAN_VALIDATION_PASS")
+
+    def test_alias_plan_ok_to_canonical(self):
+        self._write("validator output...\nPLAN_OK\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
+        self.assertEqual(r, "PLAN_VALIDATION_PASS")
+
+    def test_alias_plan_approve_to_canonical(self):
+        self._write("validator output...\nPLAN_APPROVE\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
+        self.assertEqual(r, "PLAN_VALIDATION_PASS")
+
+    def test_alias_design_lgtm(self):
+        self._write("output\nDESIGN_LGTM\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "DESIGN_REVIEW_PASS|DESIGN_REVIEW_FAIL")
+        self.assertEqual(r, "DESIGN_REVIEW_PASS")
+
+    def test_alias_in_marker_block(self):
+        # ---MARKER:PLAN_OK--- 정형 안에 alias 들어와도 잡혀야
+        self._write("output\n---MARKER:PLAN_OK---\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
+        self.assertEqual(r, "PLAN_VALIDATION_PASS")
+
+    def test_alias_only_when_canonical_in_expected(self):
+        # 호출자가 PLAN_VALIDATION_* 기대 안 하면 alias 도 적용 안 됨
+        # (DESIGN 컨텍스트에서 PLAN_LGTM 입력 → UNKNOWN)
+        self._write("output\nPLAN_LGTM\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "DESIGN_REVIEW_PASS|DESIGN_REVIEW_FAIL")
+        self.assertEqual(r, "UNKNOWN")
+
+    def test_unknown_when_no_canonical_no_alias(self):
+        self._write("output without any marker\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL")
+        self.assertEqual(r, "UNKNOWN")
+
+    def test_canonical_takes_precedence_over_alias(self):
+        # 같은 파일에 canonical + alias 모두 있으면 canonical 우선
+        self._write("PLAN_LGTM\n---MARKER:PLAN_VALIDATION_PASS---\n")
+        r = self.core.parse_marker(self.tmp.name,
+                                   "PLAN_VALIDATION_PASS|PLAN_VALIDATION_FAIL|PASS|FAIL")
+        self.assertEqual(r, "PLAN_VALIDATION_PASS")  # 같은 결과지만 1차 매치 경로
+
+    def test_general_approve_to_pass(self):
+        self._write("output\nAPPROVE\n")
+        r = self.core.parse_marker(self.tmp.name, "PASS|FAIL|SPEC_MISSING")
+        self.assertEqual(r, "PASS")
+
+    def test_reject_to_fail(self):
+        self._write("output\nREJECT\n")
+        r = self.core.parse_marker(self.tmp.name, "PASS|FAIL")
+        self.assertEqual(r, "FAIL")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

PR #8 의 canonical 마커 + preamble 절대 룰이 *이미 적용된 상태* (jajang 의 plugin cache 가 RWHarness main 으로 symlink — 변경 즉시 live) 에서도 validator 가 `PLAN_OK` / `APPROVE` 변형 emit → 또 ESCALATE.

근본 원인: agent docs 강화는 *주 방어선* 이나 LLM 이 룰 따르지 않는 사례 존재. **defense in depth** 필요.

## 변경

`harness/core.py`:
- `MARKER_ALIASES` dict 신규 — 검증된 LLM 변형 → canonical 매핑
- `parse_marker` 3차 폴백 추가:
  1. `---MARKER:X---` (canonical 정형)
  2. `\bX\b` (canonical 워드 바운더리)
  3. **alias map** + 호출자 expected set 일 때만 normalize + stderr 경고

## Alias map (요약)

| 컨텍스트 | 변형 | Canonical |
|---|---|---|
| PLAN | PLAN_LGTM / PLAN_OK / PLAN_APPROVE / PLAN_APPROVED | PLAN_VALIDATION_PASS |
| PLAN | PLAN_REJECT / PLAN_REJECTED / PLAN_NOT_APPROVED | PLAN_VALIDATION_FAIL |
| DESIGN | DESIGN_LGTM / DESIGN_OK / DESIGN_APPROVE | DESIGN_REVIEW_PASS |
| DESIGN | DESIGN_REJECT / DESIGN_REJECTED | DESIGN_REVIEW_FAIL |
| BUGFIX | BUGFIX_LGTM / BUGFIX_OK / BUGFIX_APPROVE | BUGFIX_PASS |
| UX | UX_LGTM / UX_OK / UX_APPROVE | UX_REVIEW_PASS |
| UX | UX_REJECT | UX_REVIEW_FAIL |
| CODE | CODE_LGTM / CODE_OK / CODE_APPROVE | PASS |
| 일반 | APPROVE / APPROVED / OK | PASS |
| 일반 | REJECT / REJECTED / NOT_APPROVED | FAIL |

## False positive 보호

- **LGTM 단독 매핑 안 함** — pr-reviewer 의 정식 마커와 충돌 회피
- **호출자 expected set 검증** — `parse_marker(file, "DESIGN_REVIEW_PASS|...")` 호출에 PLAN_LGTM 입력 시 → UNKNOWN (PLAN→DESIGN 차용 차단)
- **canonical 우선** — 같은 파일에 canonical + alias 모두 있으면 1차/2차 매치

## Test plan

- [x] `python3 -m unittest tests.pytest.test_tracker` — 44/44 OK (신규 ParseMarkerAliasTests 11)
  - canonical_marker_still_works
  - alias_plan_lgtm_to_canonical (jajang 1차 사례)
  - alias_plan_ok_to_canonical (jajang 2차 사례)
  - alias_plan_approve_to_canonical
  - alias_design_lgtm
  - alias_in_marker_block (`---MARKER:PLAN_OK---` 도 잡힘)
  - alias_only_when_canonical_in_expected (false positive 차단)
  - unknown_when_no_canonical_no_alias
  - canonical_takes_precedence_over_alias
  - general_approve_to_pass
  - reject_to_fail
- [x] `bash scripts/smoke-test.sh` — 56/56 (회귀 없음)

## Linked

- jajang 사례 (2026-04-28) — PLAN_OK / APPROVE 변형 emit (`/harness-review` 출력 transcript)
- `HARNESS-CHG-20260428-08` (PR #8) — agent docs canonical 룰. *주 방어선*. 본 PR 은 *defense in depth*

🤖 Generated with [Claude Code](https://claude.com/claude-code)