### PR TITLE
HARNESS-CHG-20260428-10 migration audit cleanup (4건)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ cd /path/to/your-project
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-rwh.sh"
 ```
 
-### C. ~/.claude 에 source 시스템이 있는 사용자 — 마이그레이션
+### C. ~/.claude 에 source 시스템이 있는 *기존* 사용자만 — 마이그레이션
+
+> **신규 사용자는 §A 사용. §C 는 *과거에 ~/.claude 에 직접 hooks/, harness/, agents/ 를 두고 사용하던* 사용자 전용 경로.**
 
 기존 ~/.claude 에 RWHarness 의 source(hooks/, harness/, agents/ 등)가 활성화돼있다면 **충돌 회피 정리 후 install** 필요. step-by-step: [`docs/migration-from-source.md`](docs/migration-from-source.md). 백업 → 플러그인 install → settings.json hooks 제거 → source 디렉토리 삭제 → 검증.
 

--- a/harness/notify.py
+++ b/harness/notify.py
@@ -16,7 +16,7 @@
 
 ### 호출
 - `harness/core.py::RunLogger.write_run_end` 에서 자동 호출
-- CLI 테스트: `python3 ~/.claude/harness/notify.py HARNESS_DONE mb 129 2712 3.42`
+- CLI 테스트: `python3 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/notify.py" HARNESS_DONE mb 129 2712 3.42`
 """
 
 from __future__ import annotations

--- a/hooks/harness-settings-watcher.py
+++ b/hooks/harness-settings-watcher.py
@@ -39,7 +39,7 @@ if is_global and hooks_changed:
             "hookEventName": "PostToolUse",
             "additionalContext": (
                 "⚠️ [GLOBAL HARNESS] settings.json hooks 섹션 변경됨\n"
-                "→ PreToolUse/PostToolUse 훅을 추가/수정했다면 ~/.claude/setup-harness.sh에도 반영 필요\n"
+                "→ PreToolUse/PostToolUse 훅을 추가/수정했다면 플러그인의 `hooks/hooks.json` 또는 `scripts/setup-rwh.sh`에도 반영 필요\n"
                 "→ allowedTools / permissions / enabledPlugins 변경은 해당 없음"
             )
         }
@@ -51,7 +51,7 @@ elif not is_global and hooks_changed:
             "hookEventName": "PostToolUse",
             "additionalContext": (
                 "🚫 [HARNESS] 프로젝트 settings.json에 hooks 섹션 추가 금지!\n"
-                "모든 훅은 ~/.claude/settings.json(전역)에서만 관리한다.\n"
+                "모든 훅은 플러그인의 `hooks/hooks.json` (자동 로드) 또는 전역 `~/.claude/settings.json` 에서만 관리한다.\n"
                 "프로젝트 settings.json에는 env + allowedTools만 허용.\n"
                 "→ 방금 추가한 hooks를 즉시 제거하라."
             )

--- a/hooks/plugin-write-guard.py
+++ b/hooks/plugin-write-guard.py
@@ -80,7 +80,7 @@ def main() -> None:
                 "정상 경로:\n"
                 "- 커스텀 스킬/커맨드는 ~/.claude/commands/*.md 에 두세요.\n"
                 "- 에이전트 프로젝트 컨텍스트는 .claude/agent-config/*.md 에 두세요.\n"
-                "- 오피셜 플러그인 버그는 선행 훅(~/.claude/hooks/*.py)으로 우회하세요.\n"
+                "- 오피셜 플러그인 버그는 선행 훅(`${CLAUDE_PLUGIN_ROOT}/hooks/*.py` 또는 자체 플러그인의 hooks)으로 우회하세요.\n"
                 f"- 정말 필요하면: export {ALLOW_ENV}=1 후 같은 세션에서 재시도."
             )
 

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -53,6 +53,7 @@
 | `HARNESS-CHG-20260428-07` | 2026-04-28 | infra | [7.1] migration audit — `~/.claude/scripts/`, `~/.claude/setup-harness.sh`, `~/.claude/agents/{agent}.md` 잔존 hardcode 5 파일 9 위치 일괄 env-aware 교체 (PR #4 systematic 후속) | `Document-Exception: harness-architecture.md 단일 행 path 정정 — 의사결정 변경 없는 문구 fix 라 rationale 4섹션 불필요. 본 Task-ID 본문 섹션이 동기·범위 명시` |
 | `HARNESS-CHG-20260428-08` | 2026-04-28 | agent | [8.1] validator sub-docs canonical 마커 — plan/code/design/bugfix-validation 출력 형식 `---MARKER:X---` 정형화 + preamble 마커명 정확도 절대 룰 추가 (PLAN_LGTM 변형 차단) | — |
 | `HARNESS-CHG-20260428-09` | 2026-04-28 | infra | [9.1] parse_marker alias map — LLM 변형(PLAN_LGTM/PLAN_OK/PLAN_APPROVE/APPROVE/REJECT 등) → canonical 흡수. 3차 폴백 + stderr 경고. agent docs 강화로 안 풀린 PLAN_OK/APPROVE 사례(jajang 2026-04-28) defense in depth | — |
+| `HARNESS-CHG-20260428-10` | 2026-04-28 | infra | [10.1] migration audit cleanup — notify.py:19 CLI 예시 + plugin-write-guard:83 + settings-watcher:42,54 메시지 + README §C 신규 사용자 혼동 차단 (4건 일괄, MCP graceful 별도 검토) | — |
 
 ---
 
@@ -590,6 +591,46 @@ RWHarness commands/harness-review.md:21 → ~/.claude/scripts/harness-review.py 
 **Linked**:
 - jajang 사례 (2026-04-28) `PLAN_OK / APPROVE` 변형 emit
 - `HARNESS-CHG-20260428-08` (PR #8) — agent docs canonical 룰. *주 방어선*. 본 PR 은 *defense in depth* 보완
+
+**Exception**: —
+
+---
+
+## `HARNESS-CHG-20260428-10` — 2026-04-28 — migration audit cleanup (4건)
+
+**Type**: infra (코드 + README)
+
+**Branch**: `harness/audit-cleanup`
+
+**Issue**: 마이그레이션 systematic audit (`HARNESS-CHG-20260428-07` 후속) 잔존 4건 정리.
+
+**[10.1] 4건 일괄**:
+
+1. `harness/notify.py:19` (HIGH — 테스터 차단) — CLI 테스트 예시 `~/.claude/harness/notify.py` 가 마이그레이션으로 삭제된 경로
+   → `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/realworld-harness}/harness/notify.py`
+
+2. `hooks/plugin-write-guard.py:83` (MID — 메시지 정확도) — 우회 안내가 `~/.claude/hooks/*.py` 로 되어 있으나 플러그인 모드에선 `${CLAUDE_PLUGIN_ROOT}/hooks/`
+   → "${CLAUDE_PLUGIN_ROOT}/hooks/*.py 또는 자체 플러그인의 hooks"
+
+3. `hooks/harness-settings-watcher.py:42,54` (MID — 메시지 정확도) — 글로벌 hooks 변경 시 안내 메시지가 *삭제된* `~/.claude/setup-harness.sh` 를 가리킴
+   → 라인 42: "플러그인의 `hooks/hooks.json` 또는 `scripts/setup-rwh.sh`에도 반영 필요"
+   → 라인 54: "플러그인의 `hooks/hooks.json` (자동 로드) 또는 전역 `~/.claude/settings.json` 에서만 관리"
+
+4. `README.md` §C (MID-HIGH — 신규 사용자 혼동) — 옵션 A/B/C 구조에서 §C 가 "기존 사용자 전용" 임이 모호 → 신규가 잘못 진입 가능
+   → §C 헤더에 "*기존* 사용자만" 추가 + 명시적 경고 박스 ("**신규 사용자는 §A 사용. §C 는 과거에 ~/.claude 에 직접 hooks/, harness/, agents/ 를 두고 사용하던 사용자 전용 경로**")
+
+**비변경 (의도)**:
+- audit 발견 5번 (MCP 도구 hard-fail) — qa.md / designer.md 는 PR #1 에서 Bash + tracker CLI 폴백 이미 추가됨. architect/ux-architect 는 design-only flow 로 한정. critical 아님 → 별도 검토
+- audit 발견 9번 (업스트림 후속 변경 갭) — Phase 4 마이그레이션 완료 단계의 기술 부채. 긴급 아님
+
+**검증**:
+- `python3 -m py_compile harness/notify.py hooks/plugin-write-guard.py hooks/harness-settings-watcher.py` — OK
+- `python3 -m unittest tests.pytest.test_tracker` — 44/44 OK
+- `bash scripts/smoke-test.sh` — 56/56 PASS
+
+**Linked**:
+- `HARNESS-CHG-20260428-07` (PR #7) — migration systematic audit. 본 PR 은 그 audit 의 잔존 4건 정리
+- audit 보고서 (subagent 결과, 2026-04-28)
 
 **Exception**: —
 


### PR DESCRIPTION
## Summary

`HARNESS-CHG-20260428-07` (PR #7) migration systematic audit 의 잔존 4건 일괄 처리.

## 수정 (4건)

| # | 파일:라인 | 우선도 | 변경 |
|---|---|---|---|
| 1 | `harness/notify.py:19` | **HIGH** | CLI 테스트 예시 `~/.claude/harness/notify.py` (삭제된 경로) → `${CLAUDE_PLUGIN_ROOT}/harness/notify.py` |
| 2 | `hooks/plugin-write-guard.py:83` | MID | deny 메시지 우회 안내 → `${CLAUDE_PLUGIN_ROOT}/hooks/` 또는 자체 플러그인 |
| 3 | `hooks/harness-settings-watcher.py:42,54` | MID | 두 안내 메시지 — `~/.claude/setup-harness.sh` (삭제됨) → 플러그인의 `hooks/hooks.json` / `scripts/setup-rwh.sh` |
| 4 | `README.md` §C | MID-HIGH | 신규 사용자 혼동 차단 — "기존 사용자만" 명시 + 경고 박스 |

## 비변경 (의도)

- **audit 발견 5번 (MCP hard-fail)** — qa.md / designer.md 는 PR #1 에서 Bash + tracker CLI 폴백 이미 추가. architect / ux-architect 는 design-only flow 한정 → critical 아님. 별도 검토.
- **audit 발견 9번 (업스트림 후속 변경 갭)** — Phase 4 마이그레이션 완료 단계의 기술 부채. 긴급 아님.

## Test plan

- [x] `python3 -m py_compile harness/notify.py hooks/plugin-write-guard.py hooks/harness-settings-watcher.py` — syntax OK
- [x] `python3 -m unittest tests.pytest.test_tracker` — 44/44 OK
- [x] `bash scripts/smoke-test.sh` — 56/56 PASS (회귀 없음)

## Linked

- `HARNESS-CHG-20260428-07` (PR #7) — migration systematic audit (이번 PR 의 모태)
- audit subagent 보고서 (2026-04-28) — 9개 차원 전수 대조

🤖 Generated with [Claude Code](https://claude.com/claude-code)