### PR TITLE
HARNESS-CHG-20260428-14 [14.3] TDD 순서 강제 — test_command 의존성 제거

### DIFF
--- a/harness/impl_loop.py
+++ b/harness/impl_loop.py
@@ -924,8 +924,12 @@ def _run_std_deep(
         os.environ["HARNESS_HIST_DIR"] = str(attempt_dir)
         prune_history(str(loop_out_dir))
 
-        # ── TDD Phase: test-engineer 선행 (attempt 0 + test_command + std/deep) ──
-        _tdd_active = (attempt == 0 and bool(config.test_command) and depth in ("std", "deep"))
+        # ── TDD Phase: test-engineer 선행 (attempt 0 + std/deep) ──
+        # test_command 부재가 TDD 자체를 끄지 않는다 — 테스트 작성은 회귀 방어 +
+        # impl 명세 검증 목적도 있음. config.test_command 가 있을 때만 RED/GREEN
+        # 실측 게이트가 추가될 뿐. 폴백(engineer→test-engineer) 분기 제거됨
+        # (TDD 룰 위반: test 먼저 → code 뒤).
+        _tdd_active = (attempt == 0 and depth in ("std", "deep"))
         if _tdd_active:
             log_phase("test-engineer-tdd", run_logger, attempt)
             hlog_fn(f"test-engineer TDD 시작 (attempt=0, depth={depth})")
@@ -1201,82 +1205,12 @@ def _run_std_deep(
             run_logger.log_event({"event": "commit", "hash": early_commit, "attempt": attempt + 1, "t": int(time.time())})
             hlog_fn(f"early commit: {early_commit} (attempt={attempt + 1})")
 
-        # ── TDD 여부에 따라 test-engineer 처리 분기 ─────────────────
-        if _tdd_active or (attempt > 0 and depth in ("std", "deep")):
-            # TDD: test-engineer 이미 완료 (attempt 0) 또는 스킵 (attempt 1+)
-            # → 바로 vitest GREEN 확인으로 진행
-            hlog_fn("test-engineer 스킵 (TDD: 이미 완료 or attempt 1+)")
-        elif not config.test_command:
-            # test_command 미설정 시 기존 순서 폴백 (engineer → test-engineer)
-            _eng_output = ""
-            try:
-                _eng_output = Path(str(state_dir.path / f"{prefix}_eng_out.txt")).read_text(encoding="utf-8", errors="replace")
-            except OSError:
-                pass
-            _handoff_content = generate_handoff(
-                "engineer", "test-engineer", _eng_output,
-                impl_file, attempt, issue_num,
-                acceptance_criteria=extract_acceptance_criteria(impl_file),
-            )
-            _handoff_path = write_handoff(state_dir, prefix, attempt, "engineer", "test-engineer", _handoff_content)
-            run_logger.log_event({
-                "event": "handoff", "from": "engineer", "to": "test-engineer",
-                "t": int(time.time()),
-            })
-
-            r_changed = subprocess.run(["git", "diff", "HEAD~1", "--name-only"], capture_output=True, text=True, timeout=5)
-            if r_changed.returncode != 0:
-                r_changed = subprocess.run(["git", "status", "--short"], capture_output=True, text=True, timeout=5)
-                changed_files_str = " ".join(
-                    line.split(None, 1)[1] for line in r_changed.stdout.splitlines()
-                    if re.match(r"^ M|^M |^A ", line)
-                )
-            else:
-                changed_files_str = " ".join(r_changed.stdout.strip().splitlines())
-
-            log_phase("test-engineer", run_logger, attempt)
-            hlog_fn(f"test-engineer 시작 (depth={depth}, timeout=900s)")
-            kill_check(state_dir)
-            hud.agent_start("test-engineer")
-
-            _te_handoff_hint = f"\n인수인계 문서: {_handoff_path}" if _handoff_path else ""
-            # test_command 없는 폴백: TDD 모드로 호출하되 실행 금지 지시
-            te_prompt = (
-                f"@MODE:TEST_ENGINEER:TDD\n"
-                f'@PARAMS: {{ "impl_path": "{impl_file}" }}\n\n'
-                f"[지시] impl + 구현 코드 기반으로 테스트 작성. 테스트 실행은 하지 마라 (test_command 미설정).\n"
-                f"수정된 파일: {changed_files_str}\n"
-                f"issue: {format_ref(issue_num)}"
-                f"{_te_handoff_hint}"
-            )
-
-            # fallback: test-engineer 호출 (test_command 없을 때)
-            te_out = str(state_dir.path / f"{prefix}_te_out.txt")
-            agent_exit = agent_call("test-engineer", 900, te_prompt, te_out, run_logger, config, str(attempt_dir))
-            hlog_fn(f"test-engineer 종료 (exit={agent_exit})")
-            total_cost = budget_check("test-engineer", te_out, total_cost, config.max_total_cost, state_dir, prefix, config=config)
-
-            if not check_agent_output("test-engineer", te_out):
-                fail_type = "test_fail"
-                error_trace = f"test-engineer agent produced no output (exit={agent_exit})"
-                append_failure(impl_file, fail_type, error_trace, state_dir, prefix)
-                rollback_attempt(attempt, run_logger)
-                attempt += 1
-                continue
-
-            # test_command 없으므로 마커 기반 판정
-            te_marker = parse_marker(te_out, "TESTS_PASS|TESTS_FAIL|TESTS_WRITTEN")
-            if te_marker == "TESTS_FAIL":
-                fail_type = "test_fail"
-                te_content = Path(te_out).read_text(encoding="utf-8", errors="replace")
-                log_decision("fail_type", fail_type, "test-engineer reported TESTS_FAIL", run_logger, attempt)
-                append_failure(impl_file, "test_fail", te_content, state_dir, prefix)
-                rollback_attempt(attempt, run_logger)
-                attempt += 1
-                continue
-            state_dir.flag_touch(Flag.TEST_ENGINEER_PASSED)
-            hud.agent_done("test-engineer", 0, 0.0)
-            print("[HARNESS] test-engineer PASS (fallback)")
+        # ── test-engineer 단계: TDD phase 에서 attempt 0 에 이미 선행 완료, ──
+        # ── attempt 1+ 는 위 elif 에서 스킵 처리됨. 여기선 로그만 남김. ──
+        # 옛 폴백(engineer → test-engineer, test_command 미설정 시) 제거 — TDD
+        # 룰("test 먼저, code 뒤") 위반이라 jajang 류 std/deep 프로젝트에서
+        # engineer 가 test-engineer 보다 먼저 실행되던 사고 차단.
+        hlog_fn("test-engineer 스킵 (TDD: attempt 0 선행 완료 or attempt 1+ 재사용)")
 
         # ── GREEN 확인 (vitest run) ───────────────────────────────
         import shlex as _shlex

--- a/orchestration/changelog.md
+++ b/orchestration/changelog.md
@@ -60,6 +60,7 @@
 | `HARNESS-CHG-20260428-13.2` | 2026-04-28 | infra | Phase 2 Iter 2 (W2+W4) — 5 가드 + 1 ralph fallback + Layered Defense 보강. config.py engineer_scope 필드 + tracker.MUTATING_SUBCOMMANDS SSOT + harness_common 4개 헬퍼(_load_engineer_scope/auto_gc_stale_flag/_verify_live_json_writable/_STATIC_ENGINEER_SCOPE) + session_state.update_live 쓰기 실패 stderr 표준화 + executor.py round-trip canary(always-on) + HARNESS_ACTIVE flag heartbeat + agent-boundary/commit-gate/agent-gate/skill-gate/skill-stop-protect V2 분기 + ralph-session-stop 3-layer fallback(HARNESS_GUARD_V2_RALPH_FALLBACK, default off). 모든 V2 env unset 시 v1 동작 100% 회귀 0. py_compile + smoke-test 57/57 PASS. | — |
 | `HARNESS-CHG-20260428-14.1` | 2026-04-28 | infra | MARKER_ALIASES 12개 변형 추가 — PLAN_VALIDATION(PLAN_VALIDATED/PLAN_VERIFIED/PLAN_PASS/PLAN_INVALID) + LIGHT_PLAN_READY(LIGHT_PLAN_DONE/LIGHT_PLAN_COMPLETE/LIGHT_PLAN_WRITTEN/BUGFIX_PLAN_READY) + READY_FOR_IMPL(MODULE_PLAN_READY/MODULE_PLAN_DONE/IMPL_PLAN_READY/IMPL_READY/PLAN_DONE/PLAN_WRITTEN/PLAN_COMPLETE). validator/architect 가 canonical 대신 자유 텍스트 변형 emit 시 SPEC_GAP_ESCALATE / PLAN_VALIDATION_ESCALATE 로 attempt 무위 소진되던 사례 차단. defense in depth 2nd layer 두꺼워짐. | — |
 | `HARNESS-CHG-20260428-14.2` | 2026-04-28 | infra | WorktreeManager.create_or_reuse 에 untracked plan 파일 자동 복사 추가 — `git worktree add` 직후 main repo `ls-files --others --exclude-standard` 결과 중 `docs/bugfix/`, `docs/impl/`, `docs/milestones/` prefix 파일을 worktree 같은 상대경로로 cp. architect 가 main repo 에 LIGHT_PLAN 작성 후 commit 전 worktree 진입하면 engineer 가 'impl 파일 없음' no_changes 로 attempt 0 무위 소진되던 사고 차단. 안전 패턴: plan 디렉토리만 — src/ 등은 worktree 경계 보호 위해 제외. | — |
+| `HARNESS-CHG-20260428-14.3` | 2026-04-28 | infra | TDD 순서 강제 — impl_loop.py:928 `_tdd_active` 조건에서 `bool(config.test_command)` 의존성 제거. 1209 의 옛 폴백(engineer→test-engineer, OLD 순서) elif 블록 제거. test_command 부재가 TDD 자체를 끄지 않도록 — 테스트 작성은 회귀 방어 + impl 명세 검증 목적도 있고, RED/GREEN 실측 게이트만 test_command 가드 유지. jajang 류 std/deep 프로젝트에서 engineer 가 test-engineer 보다 먼저 실행되던 룰 위반 차단. | — |
 
 ---
 
@@ -888,6 +889,38 @@ def _resolve_plugin_root() -> Path:
 **Linked**:
 - 선행 `HARNESS-CHG-20260428-14.1` — 같은 묶음의 1번째 fix.
 - 후속 (이번 6건 묶음): C3 TDD 순서 / C4 pr-reviewer scope / C5 no_changes 분리.
+
+**Exception**: —
+
+---
+
+## `HARNESS-CHG-20260428-14.3` — 2026-04-28 — TDD 순서 강제 (test_command 의존성 제거)
+
+**Type**: infra (워크플로우 룰 무결성)
+
+**Branch**: `harness/tdd-order-strict`
+
+**Issue**: `impl_loop.py:928` `_tdd_active = (attempt == 0 and bool(config.test_command) and depth in ("std", "deep"))` 조건이 `test_command` 미설정 프로젝트(예: jajang `harness.config.json` `"test_command": ""`)에선 `_tdd_active=False` → 1209 의 옛 폴백(engineer→test-engineer) 분기로 빠짐 → engineer 가 test-engineer 보다 먼저 실행 → TDD 룰("test 먼저, code 뒤") 정반대.
+
+**범위 요약**:
+- `harness/impl_loop.py:928` `_tdd_active` 조건에서 `bool(config.test_command) and ` 제거.
+  - 결과: `_tdd_active = (attempt == 0 and depth in ("std", "deep"))`. test_command 유무와 무관하게 std/deep attempt 0 이면 test-engineer 선행.
+- `harness/impl_loop.py:1209` `elif not config.test_command:` 폴백 블록 (~70 line) 제거.
+  - 옛 의도: test_command 가 없으면 TDD 의미가 없다고 판단해 engineer 먼저, test-engineer 나중. 그러나 테스트 작성 자체는 회귀 방어 + impl 명세 검증 목적도 있어 TDD 룰을 끄면 안 됨.
+- RED/GREEN 실측 게이트(`if _tdd_test_files and config.test_command:` 974, `if config.test_command:` 1283 부근)는 그대로 유지 — test_command 없으면 실행 게이트만 자연 스킵, 테스트 작성은 항상 함.
+- `_tdd_active or (attempt > 0 and depth in ("std", "deep"))` 분기는 `_run_std_deep` 가 항상 std/deep 으로만 호출되므로 결과적으로 항상 True — 단순 로그로 정리.
+
+**검증**:
+- `python3 -m py_compile harness/impl_loop.py` — OK.
+- AST 점검 — `_tdd_active` 라인 932: `attempt == 0 and depth in ('std', 'deep')` ✓ (test_command 의존 없음).
+
+**비변경 (의도)**:
+- simple depth — `run_simple` 가 별도 함수, test-engineer 자체가 스킵 (line 731-735). 변경 없음.
+- agent docs `agents/test-engineer.md` — TDD 모드 명세는 그대로. 호출 조건만 정정.
+
+**Linked**:
+- 선행 `HARNESS-CHG-20260428-14.1`/`14.2` — 같은 묶음.
+- 후속: C4 pr-reviewer scope / C5 no_changes 분리.
 
 **Exception**: —
 


### PR DESCRIPTION
## Summary

- impl_loop.py:928 _tdd_active 조건에서 bool(config.test_command) 제거
- 1209 옛 폴백 elif (engineer→test-engineer, 약 70 line) 제거
- RED/GREEN 실측 게이트는 test_command 가드 유지

## Why

test_command 미설정 프로젝트(jajang 등)에서 _tdd_active=False → 옛 폴백 → engineer 가 test-engineer 보다 먼저 실행됨. TDD 룰("test 먼저, code 뒤") 정반대. test_command 유무는 RED/GREEN 실측 게이트에만 영향줘야지 TDD 자체를 끄면 안 됨.

## Test plan

- [x] py_compile harness/impl_loop.py — OK
- [x] AST 점검 — _tdd_active = (attempt == 0 and depth in ('std', 'deep')) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)